### PR TITLE
Make sure library directory exists

### DIFF
--- a/VirtualCore/Source/Models/VBVirtualMachine.swift
+++ b/VirtualCore/Source/Models/VBVirtualMachine.swift
@@ -80,7 +80,7 @@ public extension VBVirtualMachine {
     
     init(bundleURL: URL) throws {
         if !FileManager.default.fileExists(atPath: bundleURL.path) {
-            try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: false)
+            try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
         }
         
         self.bundleURL = bundleURL


### PR DESCRIPTION
Hi, had a minor hitch where ~/Documents/VirtualBuddy didn't exist and it failed to create my first vm from an ipsw.