### PR TITLE
Fix "Unknown networking error" when downloading restore image

### DIFF
--- a/VirtualCore/Source/Restore Images/VBDownloader.swift
+++ b/VirtualCore/Source/Restore Images/VBDownloader.swift
@@ -151,7 +151,9 @@ extension VBDownloader: URLSessionDownloadDelegate, URLSessionDelegate {
     }
 
     public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        state = .failed(error?.localizedDescription ?? "Unknown networking error.")
+        // Successful completion is handled in `urlSession:downloadTask:didFinishDownloadingTo`.
+        guard let error = error else { return }
+        state = .failed(error.localizedDescription)
     }
 
     public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {


### PR DESCRIPTION
This is kind of embarrassing. It had been a long time since I last implemented the `URLSession` delegate callbacks, and in the rush to implement this feature I ended up assuming that `didCompleteWithError` would only be called when the task had failed, but in fact it is called with a `nil` error when the task has completed successfully. Whoops 😅