### PR TITLE
Display download link below selected restore image

### DIFF
--- a/VirtualBuddy/Installer/VMInstallationWizard.swift
+++ b/VirtualBuddy/Installer/VMInstallationWizard.swift
@@ -105,6 +105,13 @@ struct VMInstallationWizard: View {
                 }
             }
 
+            if let selectedImage = viewModel.data.restoreImageInfo {
+                Text(selectedImage.downloadNotice)
+                .foregroundColor(.secondary)
+                .textSelection(.enabled)
+                .padding(.top)
+            }
+
             if let authRequirement = viewModel.data.restoreImageInfo?.authenticationRequirement {
                 authenticationEntryPoint(with: authRequirement)
                     .padding(.top, 36)
@@ -232,4 +239,16 @@ struct VMInstallationWizard_Previews: PreviewProvider {
     static var previews: some View {
         VMInstallationWizard()
     }
+}
+
+extension VBRestoreImageInfo {
+
+    var downloadNotice: String {
+        """
+        If you prefer to use a download manager, you may download \(name) from the following URL:
+
+        \(url)
+        """
+    }
+
 }


### PR DESCRIPTION
We don't support resuming downloads just yet (#3). This makes it easier for folks to manually download the restore image using a download manager by displaying the download link below the selected option.