### PR TITLE
Using value types for NSViewControllerRepresentable implementations (#23)

### DIFF
--- a/VirtualBuddy/Installer/Components/AuthenticatingWebView.swift
+++ b/VirtualBuddy/Installer/Components/AuthenticatingWebView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import WebKit
 
-final class AuthenticatingWebView: NSViewControllerRepresentable {
+struct AuthenticatingWebView: NSViewControllerRepresentable {
 
     typealias NSViewControllerType = AuthenticatingWebViewController
 
@@ -21,9 +21,9 @@ final class AuthenticatingWebView: NSViewControllerRepresentable {
     }
 
     func makeNSViewController(context: Context) -> AuthenticatingWebViewController {
-        AuthenticatingWebViewController(url: url) { [weak self] 🍪 in
+        AuthenticatingWebViewController(url: url) { 🍪 in
             DispatchQueue.main.async {
-                self?.onCookiesChanged(🍪)
+                self.onCookiesChanged(🍪)
             }
         }
     }

--- a/VirtualBuddy/Session/Components/SwiftUIVMView.swift
+++ b/VirtualBuddy/Session/Components/SwiftUIVMView.swift
@@ -10,7 +10,7 @@ import Cocoa
 import Virtualization
 import VirtualCore
 
-final class SwiftUIVMView: NSViewControllerRepresentable {
+struct SwiftUIVMView: NSViewControllerRepresentable {
     
     typealias NSViewControllerType = VMViewController
     
@@ -62,7 +62,7 @@ final class VMViewController: NSViewController {
     }()
     
     override func loadView() {
-        view = VMContainerView()
+        view = NSView()
         view.wantsLayer = true
         view.layer?.backgroundColor = NSColor.black.cgColor
         
@@ -89,15 +89,5 @@ final class VMViewController: NSViewController {
         
         print("makeFirstResponder = \(result)")
     }
-    
-}
-
-fileprivate final class VMContainerView: NSView {
-    
-//    override var acceptsFirstResponder: Bool { true }
-//    
-//    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
-//    
-//    override var canBecomeKeyView: Bool { true }
     
 }


### PR DESCRIPTION
Fixes crash in macOS Ventura