### PR TITLE
Add disk image size slider when creating a VM.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ The default mode the VM OS selects for the display uses the native resolution th
 
 Xcode 14 is recommended.
 
-- Edit `Main.xcconfig` and set the `VB_BUNDLE_ID_PREFIX` variable to something unique like `com.yourname.`, then select a team under Signing & Capabilities.
+- Edit `Signing.xcconfig` and set the `VB_BUNDLE_ID_PREFIX` variable to something unique like `com.yourname.`, then select a team under Signing & Capabilities.
 	- You may optionally run with the "Sign to run locally" option to skip this step
 - Build the `VirtualBuddy` scheme

--- a/VirtualBuddy/Installer/VMInstallationWizard.swift
+++ b/VirtualBuddy/Installer/VMInstallationWizard.swift
@@ -24,6 +24,8 @@ struct VMInstallationWizard: View {
                         restoreImageURLInput
                     case .restoreImageSelection:
                         restoreImageSelection
+                    case .configure:
+                        configureVM
                     case .name:
                         renameVM
                     case .download:
@@ -195,6 +197,28 @@ struct VMInstallationWizard: View {
             .frame(minWidth: 500, maxWidth: .infinity, minHeight: 550, maxHeight: .infinity)
         })
     }
+    
+    @ViewBuilder
+    private var configureVM: some View {
+        VStack {
+            title("Configure Your Virtual Mac")
+
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Disk Size: \(Int(viewModel.data.diskImageSize).formatted(.byteCount(style: .file)))")
+
+                Slider(value: $viewModel.data.diskImageSize,
+                       in: .minimumDiskImageSize ... .maximumDiskImageSize,
+                       step: .minimumDiskImageSize) {
+                    Text("Disk Size")
+                } minimumValueLabel: {
+                    Text(Int.minimumDiskImageSize.formatted(.byteCount(style: .file)))
+                } maximumValueLabel: {
+                    Text(Int.maximumDiskImageSize.formatted(.byteCount(style: .file)))
+                }
+                .labelsHidden()
+            }
+        }
+    }
 
     @ViewBuilder
     private var renameVM: some View {
@@ -263,8 +287,15 @@ struct VMInstallationWizard: View {
 
 }
 
+private extension Double {
+    static let defaultDiskImageSize = Double(Int.defaultDiskImageSize)
+    static let minimumDiskImageSize = Double(Int.minimumDiskImageSize)
+    static let maximumDiskImageSize = Double(Int.maximumDiskImageSize)
+}
+
 struct VMInstallationWizard_Previews: PreviewProvider {
     static var previews: some View {
         VMInstallationWizard()
+            .environmentObject(VMLibraryController.shared)
     }
 }

--- a/VirtualCore/Source/Models/VBVirtualMachine.swift
+++ b/VirtualCore/Source/Models/VBVirtualMachine.swift
@@ -10,9 +10,18 @@ public struct VBVirtualMachine: Identifiable, Hashable {
         public internal(set) var NVRAM = [VBNVRAMVariable]()
     }
     
+    public struct InstallOptions: Hashable {
+        public let diskImageSize: Int
+        
+        public init(diskImageSize: Int) {
+            self.diskImageSize = diskImageSize
+        }
+    }
+    
     public var id: String { bundleURL.absoluteString }
     public let bundleURL: URL
     public var name: String { bundleURL.deletingPathExtension().lastPathComponent }
+    public var installOptions: InstallOptions?
     
     public internal(set) var metadata: Metadata
 }
@@ -26,6 +35,7 @@ public extension VBVirtualMachine {
 public extension VBVirtualMachine {
     static let preview = VBVirtualMachine(
         bundleURL: URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("Sample.vbvm"),
+        installOptions: InstallOptions(diskImageSize: .defaultDiskImageSize),
         metadata: Metadata(
             operatingSystemVersion: "12.4",
             operatingSystemBuild: "XYZ123",
@@ -78,12 +88,13 @@ public extension UTType {
 
 public extension VBVirtualMachine {
     
-    init(bundleURL: URL) throws {
+    init(bundleURL: URL, installOptions: InstallOptions? = nil) throws {
         if !FileManager.default.fileExists(atPath: bundleURL.path) {
             try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
         }
         
         self.bundleURL = bundleURL
+        self.installOptions = installOptions
         self.metadata = try Metadata(bundleURL: bundleURL)
     }
     


### PR DESCRIPTION
Hey, thanks for creating VirtualBuddy, its a really great tool 🙌

I was struggling to fit a VM inside the 64GB disk image it creates, so here's a PR that adds an installation wizard step with a slider to increase the disk size.

Let me know if there are any changes you would like (or feel free to make them yourself, I'm not precious about PRs 🙂).

![Screenshot 2022-07-09 at 3 47 32 pm](https://user-images.githubusercontent.com/6060466/178110764-dd7adc28-ab52-45bb-b9ac-67a5fd7aa52c.png)