### PR TITLE
Tweak installer UI (#63)

### DIFF
--- a/VirtualBuddy.xcodeproj/project.pbxproj
+++ b/VirtualBuddy.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		F42C01612888FC3500EB15CD /* LibraryItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42C01602888FC3500EB15CD /* LibraryItemView.swift */; };
 		F44C00F92889C1A700640BF5 /* DuplicateVMSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44C00F82889C1A700640BF5 /* DuplicateVMSheet.swift */; };
 		F44C00FB2889CE1600640BF5 /* VBVirtualMachine+Virtualization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44C00FA2889CE1600640BF5 /* VBVirtualMachine+Virtualization.swift */; };
+		F4561A6828981B4100055289 /* VirtualMachineNameField.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4561A6728981B4100055289 /* VirtualMachineNameField.swift */; };
 		F465C3AE284F93A5006E9ED4 /* VBAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F465C3AD284F93A5006E9ED4 /* VBAPIClient.swift */; };
 		F465C3B0284F9660006E9ED4 /* VBRestoreImagesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F465C3AF284F9660006E9ED4 /* VBRestoreImagesResponse.swift */; };
 		F465C3B2284F9666006E9ED4 /* VBRestoreImageInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F465C3B1284F9666006E9ED4 /* VBRestoreImageInfo.swift */; };
@@ -222,6 +223,7 @@
 		F42C01602888FC3500EB15CD /* LibraryItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryItemView.swift; sourceTree = "<group>"; };
 		F44C00F82889C1A700640BF5 /* DuplicateVMSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicateVMSheet.swift; sourceTree = "<group>"; };
 		F44C00FA2889CE1600640BF5 /* VBVirtualMachine+Virtualization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VBVirtualMachine+Virtualization.swift"; sourceTree = "<group>"; };
+		F4561A6728981B4100055289 /* VirtualMachineNameField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualMachineNameField.swift; sourceTree = "<group>"; };
 		F465C3AD284F93A5006E9ED4 /* VBAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VBAPIClient.swift; sourceTree = "<group>"; };
 		F465C3AF284F9660006E9ED4 /* VBRestoreImagesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VBRestoreImagesResponse.swift; sourceTree = "<group>"; };
 		F465C3B1284F9666006E9ED4 /* VBRestoreImageInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VBRestoreImageInfo.swift; sourceTree = "<group>"; };
@@ -522,6 +524,7 @@
 				F48E0D14288882BD0080DDFA /* InstallationWizardTitle.swift */,
 				F48E0D17288882BD0080DDFA /* AuthenticatingWebView.swift */,
 				F42C01492888C2F800EB15CD /* InstallationConsole.swift */,
+				F4561A6728981B4100055289 /* VirtualMachineNameField.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1111,6 +1114,7 @@
 				F48E0D25288882E50080DDFA /* OnAppearOnce.swift in Sources */,
 				F422587E2885E2ED009420AE /* HardwareConfigurationView.swift in Sources */,
 				F48E0D1D288882BD0080DDFA /* AuthenticatingWebView.swift in Sources */,
+				F4561A6828981B4100055289 /* VirtualMachineNameField.swift in Sources */,
 				F48E0D34288889E60080DDFA /* InstallConfigurationStepView.swift in Sources */,
 				F42C015B2888FC0C00EB15CD /* VMSessionConfigurationView.swift in Sources */,
 				F42C015D2888FC0C00EB15CD /* SwiftUIVMView.swift in Sources */,

--- a/VirtualUI/Source/Components/HostingWindowController/WindowEnvironment.swift
+++ b/VirtualUI/Source/Components/HostingWindowController/WindowEnvironment.swift
@@ -28,6 +28,18 @@ public extension View {
     func windowTitle(_ title: String) -> some View {
         environment(\.windowTitle, title)
     }
+
+    /// Sets the title visibility for the window that contains this SwiftUI view.
+    /// Only available when the view hierarchy is being presented with `HostingWindowController`.
+    func windowTitleHidden(_ hidden: Bool) -> some View {
+        environment(\.windowTitleVisibility, hidden ? .hidden : .visible)
+    }
+
+    /// Sets whether the title bar background is hidden for the window that contains this SwiftUI view.
+    /// Only available when the view hierarchy is being presented with `HostingWindowController`.
+    func windowTitleBarTransparent(_ transparent: Bool) -> some View {
+        environment(\.windowTitleBarTransparent, transparent)
+    }
     
     /// When `true`, indicates that the view hierarchy is responsible for render its own chrome for
     /// the Cocoa window that's hosting it. Causes `HostingWindowController` to configure
@@ -81,6 +93,14 @@ private struct WindowTitleEnvironmentKey: EnvironmentKey {
     static let defaultValue: String = ""
 }
 
+private struct WindowTitleVisibilityEnvironmentKey: EnvironmentKey {
+    static let defaultValue: NSWindow.TitleVisibility = .visible
+}
+
+private struct WindowTitleBarTransparentEnvironmentKey: EnvironmentKey {
+    static let defaultValue: Bool = false
+}
+
 private struct HostingWindowKey: EnvironmentKey {
     static let defaultValue: () -> NSWindow? = { nil }
 }
@@ -122,6 +142,22 @@ extension EnvironmentValues {
         set {
             self[WindowTitleEnvironmentKey.self] = newValue
             cocoaWindow?.title = newValue
+        }
+    }
+
+    var windowTitleVisibility: NSWindow.TitleVisibility {
+        get { self[WindowTitleVisibilityEnvironmentKey.self] }
+        set {
+            self[WindowTitleVisibilityEnvironmentKey.self] = newValue
+            cocoaWindow?.titleVisibility = newValue
+        }
+    }
+
+    var windowTitleBarTransparent: Bool {
+        get { self[WindowTitleBarTransparentEnvironmentKey.self] }
+        set {
+            self[WindowTitleBarTransparentEnvironmentKey.self] = newValue
+            cocoaWindow?.titlebarAppearsTransparent = newValue
         }
     }
     

--- a/VirtualUI/Source/Installer/Components/VirtualMachineNameField.swift
+++ b/VirtualUI/Source/Installer/Components/VirtualMachineNameField.swift
@@ -1,0 +1,43 @@
+//
+//  VirtualMachineNameField.swift
+//  VirtualUI
+//
+//  Created by Guilherme Rambo on 01/08/22.
+//
+
+import SwiftUI
+import VirtualCore
+
+struct VirtualMachineNameField: View {
+    @Binding var name: String
+    var onCommit: () -> Void
+
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        HStack {
+            TextField("Virtual Mac Name", text: $name, onCommit: onCommit)
+                .textFieldStyle(.roundedBorder)
+                .controlSize(.large)
+                .focused($isFocused)
+
+            Spacer()
+
+            Button {
+                name = RandomNameGenerator.shared.newName()
+            } label: {
+                Image(systemName: "arrow.clockwise")
+                    .help("Generate new name")
+            }
+            .buttonStyle(.borderless)
+            .font(.system(size: 15, weight: .medium, design: .rounded))
+            .keyboardShortcut(.init("r", modifiers: .command))
+        }
+        .onAppearOnce {
+            DispatchQueue.main.async {
+                self.isFocused = true
+            }
+        }
+    }
+}
+

--- a/VirtualUI/Source/Installer/Steps/RestoreImagePicker.swift
+++ b/VirtualUI/Source/Installer/Steps/RestoreImagePicker.swift
@@ -90,6 +90,7 @@ struct RestoreImagePicker: View {
                 }
             }
         }
+        .controlSize(.large)
         .disabled(controller.restoreImageOptions.isEmpty)
         .onChange(of: controller.selectedRestoreImage, perform: {
             selection = $0

--- a/VirtualUI/Source/Installer/VMInstallationViewModel.swift
+++ b/VirtualUI/Source/Installer/VMInstallationViewModel.swift
@@ -72,7 +72,7 @@ final class VMInstallationViewModel: ObservableObject {
     @Published
     private(set) var restoreImageOptions = [VBRestoreImageInfo]()
 
-    @Published private(set) var buttonTitle = "Next"
+    @Published private(set) var buttonTitle = "Continue"
     @Published private(set) var showNextButton = true
     @Published  var disableNextButton = false
 

--- a/VirtualUI/Source/Installer/VMInstallationWizard.swift
+++ b/VirtualUI/Source/Installer/VMInstallationWizard.swift
@@ -21,30 +21,28 @@ public struct VMInstallationWizard: View {
 
     public var body: some View {
         VStack {
-            ZStack(alignment: .top) {
-                switch viewModel.step {
-                    case .installKind:
-                        installKindSelection
-                    case .restoreImageInput:
-                        restoreImageURLInput
-                    case .restoreImageSelection:
-                        restoreImageSelection
-                    case .configuration:
-                        configureVM
-                    case .name:
-                        renameVM
-                    case .download:
-                        downloadView
-                    case .install:
-                        installProgress
-                    case .done:
-                        finishingLine
-                }
+            switch viewModel.step {
+                case .installKind:
+                    installKindSelection
+                case .restoreImageInput:
+                    restoreImageURLInput
+                case .restoreImageSelection:
+                    restoreImageSelection
+                case .configuration:
+                    configureVM
+                case .name:
+                    renameVM
+                case .download:
+                    downloadView
+                case .install:
+                    installProgress
+                case .done:
+                    finishingLine
             }
 
-            Spacer()
-
             if viewModel.showNextButton {
+                Spacer()
+
                 Button(viewModel.buttonTitle, action: {
                     if viewModel.step == .done {
                         library.loadMachines()
@@ -60,12 +58,15 @@ public struct VMInstallationWizard: View {
         }
         .padding(viewModel.step != .configuration ? 16 : 0)
         .padding(.horizontal, viewModel.step != .configuration ? 36 : 0)
-        .frame(minWidth: 400, maxWidth: .infinity, minHeight: 400, maxHeight: .infinity, alignment: .top)
         .windowStyleMask([.titled, .closable, .resizable, .miniaturizable, .fullSizeContentView])
+        .windowTitleHidden(true)
+        .windowTitleBarTransparent(true)
         .windowTitle("New macOS VM")
         .onReceive(stepValidationStateChanged) { isValid in
             viewModel.disableNextButton = !isValid
         }
+        .edgesIgnoringSafeArea(.top)
+        .frame(minWidth: 470)
     }
 
     @ViewBuilder
@@ -83,13 +84,15 @@ public struct VMInstallationWizard: View {
             InstallationWizardTitle("Enter the URL for the macOS IPSW:")
 
             TextField("URL", text: $viewModel.provisionalRestoreImageURL, onCommit: viewModel.goNext)
+                .textFieldStyle(.roundedBorder)
+                .controlSize(.large)
         }
     }
 
     @ViewBuilder
     private var restoreImageSelection: some View {
         VStack {
-            InstallationWizardTitle("Pick a macOS Version to Download and Install")
+            InstallationWizardTitle("Pick a macOS Version to Download")
             
             RestoreImagePicker(
                 selection: $viewModel.data.restoreImageInfo,
@@ -123,22 +126,7 @@ public struct VMInstallationWizard: View {
         VStack {
             InstallationWizardTitle("Name Your Virtual Mac")
 
-            HStack {
-                TextField("VM Name", text: $viewModel.data.name, onCommit: viewModel.goNext)
-                    .textFieldStyle(.roundedBorder)
-                    .controlSize(.large)
-
-                Spacer()
-
-                Button {
-                    viewModel.data.name = RandomNameGenerator.shared.newName()
-                } label: {
-                    Image(systemName: "arrow.clockwise")
-                        .help("Generate new name")
-                }
-                .buttonStyle(.borderless)
-                .font(.system(size: 15, weight: .medium, design: .rounded))
-            }
+            VirtualMachineNameField(name: $viewModel.data.name, onCommit: viewModel.goNext)
         }
     }
 
@@ -176,7 +164,7 @@ public struct VMInstallationWizard: View {
         VStack {
             InstallationWizardTitle(vmDisplayName)
 
-            Text("Your VM is ready!")
+            Text("Your virtual Mac is ready!")
         }
     }
 

--- a/VirtualUI/Source/VM Configuration/VMConfigurationSheet.swift
+++ b/VirtualUI/Source/VM Configuration/VMConfigurationSheet.swift
@@ -39,7 +39,7 @@ public struct VMConfigurationSheet: View {
     }
     
     @Environment(\.dismiss) private var dismiss
-    
+
     public var body: some View {
         ScrollView(.vertical) {
             VMConfigurationView(initialConfiguration: initialConfiguration)


### PR DESCRIPTION
- Use list-like UI for install method
- Allow keyboard navigation when picking install method
- Ensure all text fields use the same consistent style
- Focus VM name button when that step is reached
- Add keyboard shortcut to button that generates new random names
- Fix sizing issues causing bad UX (#63)

<img width="582" alt="CleanShot 2022-08-01 at 11 38 14@2x" src="https://user-images.githubusercontent.com/67184/182175557-eac20ec3-bb48-49a7-b488-5586d868131a.png">

<img width="582" alt="CleanShot 2022-08-01 at 11 41 13@2x" src="https://user-images.githubusercontent.com/67184/182175562-69c1e95a-8c8f-4dfa-8dd2-df8dd99ff5b1.png">

