### PR TITLE
Add Xcode beta as a running requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 VirtualBuddy can virtualize macOS 12 and later on Apple Silicon, with the goal of offering features that are useful to developers who need to test their apps on multiple versions of macOS, especially betas.
 
-**Requires macOS 12.3 and an Apple Silicon Mac**
+**Requires macOS 12.3, XCode beta 14, and an Apple Silicon Mac**
 
 ⚠️ WARNING: This project is experimental. Things might break or not work as expected.
 


### PR DESCRIPTION
After experimenting and reading discussions, I thought it would be helpful to make it clear that you also need Xcode beta to run, not just to build.