### PR TITLE
Fix install wizard message to match button title

### DIFF
--- a/VirtualUI/Source/Installer/Steps/RestoreImagePicker.swift
+++ b/VirtualUI/Source/Installer/Steps/RestoreImagePicker.swift
@@ -129,7 +129,7 @@ struct RestoreImagePicker: View {
                 .foregroundColor(.secondary)
             case .alreadyDownloaded(let title, let localURL):
                 VStack {
-                    Text("\(title) is already downloaded. Click \"Next\" below to re-download it or proceed with the installation right now by using the previously downloaded image.")
+                    Text("\(title) is already downloaded. Click \"Continue\" below to re-download it or proceed with the installation right now by using the previously downloaded image.")
                         .foregroundColor(.green)
 
                     Button("Install Now") { onUseLocalFile(localURL) }


### PR DESCRIPTION
Just a little tweak for something that was bugging me. This changes the message for the `alreadyDownloaded` advisory to match the actual button title used in the app.

A quick search through the code seems to show that this title comes from the view model, but the view model never uses anything other than "Continue" and "Back to Library."

The previous state:

<img width="582" alt="Screenshot 2023-02-09 at 3 34 23 PM" src="https://user-images.githubusercontent.com/1696960/217945890-e04599c8-1ff8-4658-91b0-7e43da3a2551.png">
