### PR TITLE
Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ VirtualBuddy can virtualize macOS 12 and later on Apple Silicon, with the goal o
 - **Apple Silicon Mac**
 - macOS 12.3 or later
 - In order to install a version of macOS that's newer than the version running on the host (for example, macOS 13 VM in VirtualBuddy running on macOS 12), Xcode is required; Xcode beta may be required for installing macOS betas (`FB11061314`)
+- In order to install a Linux distro, macOS 13 is required
 
 ⚠️ WARNING: This project is experimental. Things might break or not work as expected.
 
@@ -17,11 +18,15 @@ VirtualBuddy can virtualize macOS 12 and later on Apple Silicon, with the goal o
 ### Feature Checklist
 
 - [x] Ability to boot any version of macOS 12 or macOS 13, including betas
+- [x] Ability to boot some ARM-based Linux distros (tested with Ubuntu Server and Ubuntu Desktop)
 - [x] Built-in installation wizard
 	- [x] Select from a collection of restore images available on Apple's servers
 	- [x] Install the latest stable version of macOS
 	- [x] Local restore image IPSW file
 	- [x] Custom restore image URL
+	- [x] Install a Linux distro from a local .iso file
+	- [ ] Select from a collection of Linux distros
+	- [ ] Install Linux from URL
 - [x] Boot into recovery mode (in order to disable SIP, for example)
 - [x] Networking and file sharing support
 - [x] Clipboard sharing (without the need to be running macOS Ventura) (experimental ¹)

--- a/VirtualBuddy.xcodeproj/project.pbxproj
+++ b/VirtualBuddy.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0196B45329292B2A00614EF1 /* LinuxVirtualMachineConfigurationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0196B45229292B2A00614EF1 /* LinuxVirtualMachineConfigurationHelper.swift */; };
+		4BA6BE7D293D22E500F396AE /* VirtualMachineConfigurationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BA6BE7C293D22E500F396AE /* VirtualMachineConfigurationHelper.swift */; };
 		F417255B2884D79C004FF8A7 /* FixSwiftUIMaterialInPreviews.m in Sources */ = {isa = PBXBuildFile; fileRef = F417255A2884D79C004FF8A7 /* FixSwiftUIMaterialInPreviews.m */; };
 		F417255D288604A8004FF8A7 /* SoundConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F417255C288604A8004FF8A7 /* SoundConfigurationView.swift */; };
 		F417255F28861604004FF8A7 /* DecodableDefault.swift in Sources */ = {isa = PBXBuildFile; fileRef = F417255E28861604004FF8A7 /* DecodableDefault.swift */; };
@@ -191,6 +193,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0196B45229292B2A00614EF1 /* LinuxVirtualMachineConfigurationHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinuxVirtualMachineConfigurationHelper.swift; sourceTree = "<group>"; };
+		4BA6BE7C293D22E500F396AE /* VirtualMachineConfigurationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualMachineConfigurationHelper.swift; sourceTree = "<group>"; };
 		F417255A2884D79C004FF8A7 /* FixSwiftUIMaterialInPreviews.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FixSwiftUIMaterialInPreviews.m; sourceTree = "<group>"; };
 		F417255C288604A8004FF8A7 /* SoundConfigurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundConfigurationView.swift; sourceTree = "<group>"; };
 		F417255E28861604004FF8A7 /* DecodableDefault.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecodableDefault.swift; sourceTree = "<group>"; };
@@ -647,7 +651,9 @@
 		F4A21BF028032FBD001072B8 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				4BA6BE7C293D22E500F396AE /* VirtualMachineConfigurationHelper.swift */,
 				F4BE9C7527FF055100B648F8 /* MacOSVirtualMachineConfigurationHelper.swift */,
+				0196B45229292B2A00614EF1 /* LinuxVirtualMachineConfigurationHelper.swift */,
 				F46FFBA92804F0A000D61023 /* VZVirtualMachineConfiguration+NVRAM.swift */,
 				F47FFA56280633F000BD1F87 /* VMScreenshotter.swift */,
 				F417257028877121004FF8A7 /* DiskImageGenerator.swift */,
@@ -1192,6 +1198,7 @@
 				F4A21BF428033102001072B8 /* VBError.swift in Sources */,
 				F4D0F71F2867517A004D5782 /* AppUpdateChannel.swift in Sources */,
 				F46FFBA62804E81E00D61023 /* VBObjCHookingPoint.m in Sources */,
+				4BA6BE7D293D22E500F396AE /* VirtualMachineConfigurationHelper.swift in Sources */,
 				F48E0D0728885E140080DDFA /* PreviewSupport.swift in Sources */,
 				F46FFBAA2804F0A000D61023 /* VZVirtualMachineConfiguration+NVRAM.swift in Sources */,
 				F4C189F72848F6A600335EC7 /* VirtualCoreConstants.swift in Sources */,
@@ -1211,6 +1218,7 @@
 				F4BE9C7827FF055100B648F8 /* MacOSVirtualMachineConfigurationHelper.swift in Sources */,
 				F46FFBAC28059FF600D61023 /* VMInstance.swift in Sources */,
 				F465C3B0284F9660006E9ED4 /* VBRestoreImagesResponse.swift in Sources */,
+				0196B45329292B2A00614EF1 /* LinuxVirtualMachineConfigurationHelper.swift in Sources */,
 				F465C3B2284F9666006E9ED4 /* VBRestoreImageInfo.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
+++ b/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
@@ -27,8 +27,16 @@ public struct VBMacConfiguration: Hashable, Codable {
         case unsupported([String])
     }
 
+    public enum SystemType: String, Codable, CaseIterable {
+        case mac
+        case linux
+    }
+
     public static let currentVersion = 0
     @DecodableDefault.Zero public var version = VBMacConfiguration.currentVersion
+
+    @DecodableDefault.FirstCase
+    public var systemType: SystemType = .mac
 
     public var hardware = VBMacDevice.default
     public var sharedFolders = [VBSharedFolder]()

--- a/VirtualCore/Source/Models/Configuration/DecodableDefault.swift
+++ b/VirtualCore/Source/Models/Configuration/DecodableDefault.swift
@@ -41,6 +41,7 @@ public extension DecodableDefault {
     typealias Source = DecodableDefaultSource
     typealias List = Decodable & ExpressibleByArrayLiteral
     typealias Map = Decodable & ExpressibleByDictionaryLiteral
+    typealias Enum = Decodable & CaseIterable
 
     enum Sources {
         public enum Zero: Source {
@@ -70,6 +71,10 @@ public extension DecodableDefault {
         public enum EmptyPlaceholder<T: ProvidesEmptyPlaceholder>: Source {
             public static var defaultValue: T { .empty }
         }
+        
+        public enum FirstCase<T: Enum>: Source {
+            public static var defaultValue: T { T.allCases.first! }
+        }
     }
 }
 
@@ -81,6 +86,7 @@ public extension DecodableDefault {
     typealias EmptyList<T: List> = Wrapper<Sources.EmptyList<T>>
     typealias EmptyMap<T: Map> = Wrapper<Sources.EmptyMap<T>>
     typealias EmptyPlaceholder<T: ProvidesEmptyPlaceholder> = Wrapper<Sources.EmptyPlaceholder<T>>
+    typealias FirstCase<T: Enum> = Wrapper<Sources.FirstCase<T>>
 }
 
 extension DecodableDefault.Wrapper: Equatable where Value: Equatable {}

--- a/VirtualCore/Source/Models/VBVirtualMachine.swift
+++ b/VirtualCore/Source/Models/VBVirtualMachine.swift
@@ -22,6 +22,7 @@ public struct VBVirtualMachine: Identifiable {
         public var installFinished: Bool = false
         public var firstBootDate: Date? = nil
         public var lastBootDate: Date? = nil
+        public var installImageURL: URL? = nil
     }
 
     public var id: String { bundleURL.absoluteString }
@@ -148,6 +149,16 @@ public extension VBVirtualMachine {
             self.metadata = Metadata(installFinished: true, firstBootDate: .now, lastBootDate: .now)
         }
 
+        try saveMetadata()
+    }
+
+    @available(macOS 13, *)
+    init(creatingAtURL bundleURL: URL, linuxInstallerURL: URL) throws {
+        guard !FileManager.default.fileExists(atPath: bundleURL.path) else { fatalError() }
+        try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
+        self.bundleURL = bundleURL
+        self.configuration = .init(systemType: .linux)
+        self.metadata = Metadata(installFinished: false, firstBootDate: .now, lastBootDate: .now, installImageURL: linuxInstallerURL)
         try saveMetadata()
     }
 

--- a/VirtualCore/Source/Virtualization/Helpers/LinuxVirtualMachineConfigurationHelper.swift
+++ b/VirtualCore/Source/Virtualization/Helpers/LinuxVirtualMachineConfigurationHelper.swift
@@ -1,0 +1,51 @@
+/*
+See LICENSE folder for this sample’s licensing information.
+
+Abstract:
+Helper that creates various configuration objects exposed in the `VZVirtualMachineConfiguration`.
+*/
+
+import Foundation
+import Virtualization
+
+@available(macOS 13.0, *)
+struct LinuxVirtualMachineConfigurationHelper: VirtualMachineConfigurationHelper {
+    let vm: VBVirtualMachine
+    
+    func createInstallDevice(installImageURL: URL) throws -> VZStorageDeviceConfiguration {
+        let attachment = try VZDiskImageStorageDeviceAttachment(url: installImageURL, readOnly: true)
+        let usbDeviceConfiguration = VZUSBMassStorageDeviceConfiguration(attachment: attachment)
+        return usbDeviceConfiguration
+    }
+
+    func createBootLoader() -> VZBootLoader {
+        let efi = VZEFIBootLoader()
+        let storeURL = vm.metadataDirectoryURL.appendingPathComponent("nvram")
+        if FileManager.default.fileExists(atPath: storeURL.path) {
+            efi.variableStore = VZEFIVariableStore(url: storeURL)
+        } else {
+            efi.variableStore = try? VZEFIVariableStore(creatingVariableStoreAt: storeURL, options: [])
+            // FIXME: handle errors
+        }
+        return efi
+    }
+
+    func createGraphicsDevices() -> [VZGraphicsDeviceConfiguration] {
+        let graphicsConfiguration = VZVirtioGraphicsDeviceConfiguration()
+
+        graphicsConfiguration.scanouts = vm.configuration.hardware.displayDevices.map(\.vzScanout)
+
+        return [graphicsConfiguration]
+    }
+}
+
+// MARK: - Configuration Models -> Virtualization
+
+@available(macOS 13.0, *)
+extension VBDisplayDevice {
+
+    var vzScanout: VZVirtioGraphicsScanoutConfiguration {
+        VZVirtioGraphicsScanoutConfiguration(widthInPixels: width, heightInPixels: height)
+    }
+
+}

--- a/VirtualCore/Source/Virtualization/Helpers/LinuxVirtualMachineConfigurationHelper.swift
+++ b/VirtualCore/Source/Virtualization/Helpers/LinuxVirtualMachineConfigurationHelper.swift
@@ -18,14 +18,13 @@ struct LinuxVirtualMachineConfigurationHelper: VirtualMachineConfigurationHelper
         return usbDeviceConfiguration
     }
 
-    func createBootLoader() -> VZBootLoader {
+    func createBootLoader() throws -> VZBootLoader {
         let efi = VZEFIBootLoader()
         let storeURL = vm.metadataDirectoryURL.appendingPathComponent("nvram")
         if FileManager.default.fileExists(atPath: storeURL.path) {
             efi.variableStore = VZEFIVariableStore(url: storeURL)
         } else {
-            efi.variableStore = try? VZEFIVariableStore(creatingVariableStoreAt: storeURL, options: [])
-            // FIXME: handle errors
+            efi.variableStore = try VZEFIVariableStore(creatingVariableStoreAt: storeURL, options: [])
         }
         return efi
     }

--- a/VirtualCore/Source/Virtualization/Helpers/MacOSVirtualMachineConfigurationHelper.swift
+++ b/VirtualCore/Source/Virtualization/Helpers/MacOSVirtualMachineConfigurationHelper.swift
@@ -8,86 +8,27 @@ Helper that creates various configuration objects exposed in the `VZVirtualMachi
 import Foundation
 import Virtualization
 
-struct MacOSVirtualMachineConfigurationHelper {
+struct MacOSVirtualMachineConfigurationHelper: VirtualMachineConfigurationHelper {
     let vm: VBVirtualMachine
     
-    func createBootLoader() -> VZMacOSBootLoader {
+    func createInstallDevice(installImageURL: URL) throws -> VZStorageDeviceConfiguration {
+        fatalError()
+    }
+
+    func createBootLoader() -> VZBootLoader {
         return VZMacOSBootLoader()
     }
 
-    func createBootBlockDevice() async throws -> VZVirtioBlockDeviceConfiguration {
-        do {
-            let bootDevice = try vm.bootDevice
-            let bootDiskImage = try vm.bootDiskImage
-            
-            if !bootDevice.diskImageExists(for: vm) {
-                let settings = DiskImageGenerator.ImageSettings(for: bootDiskImage, in: vm)
-                try await DiskImageGenerator.generateImage(with: settings)
-            }
-
-            let bootURL = vm.diskImageURL(for: bootDiskImage)
-            let diskImageAttachment = try VZDiskImageStorageDeviceAttachment(url: bootURL, readOnly: false)
-
-            let disk = VZVirtioBlockDeviceConfiguration(attachment: diskImageAttachment)
-
-            return disk
-        } catch {
-            throw Failure("Failed to instantiate a disk image for the VM: \(error.localizedDescription).")
-        }
+    func createGraphicsDevices() -> [VZGraphicsDeviceConfiguration] {
+        let graphicsConfiguration = VZMacGraphicsDeviceConfiguration()
+        
+        graphicsConfiguration.displays = vm.configuration.hardware.displayDevices.map(\.vzDisplay)
+        
+        return [graphicsConfiguration]
     }
-    
-    func createAdditionalBlockDevices() async throws -> [VZVirtioBlockDeviceConfiguration] {
-        var output = [VZVirtioBlockDeviceConfiguration]()
-
-        for device in vm.configuration.hardware.storageDevices {
-            guard device.isEnabled, !device.isBootVolume else { continue }
-            
-            let url = vm.diskImageURL(for: device)
-            let attachment = try VZDiskImageStorageDeviceAttachment(url: url, readOnly: device.isReadOnly)
-
-            output.append(VZVirtioBlockDeviceConfiguration(attachment: attachment))
-        }
-
-        return output
-    }    
-
-    func createKeyboardConfiguration() -> VZUSBKeyboardConfiguration {
-        return VZUSBKeyboardConfiguration()
-    }
-
 }
 
 // MARK: - Configuration Models -> Virtualization
-
-extension VBMacConfiguration {
-
-    var vzDisplays: [VZMacGraphicsDisplayConfiguration] {
-        hardware.displayDevices.map(\.vzDisplay)
-    }
-
-    var vzNetworkDevices: [VZNetworkDeviceConfiguration] {
-        get throws {
-            try hardware.networkDevices.map { try $0.vzConfiguration }
-        }
-    }
-
-    var vzAudioDevices: [VZAudioDeviceConfiguration] {
-        hardware.soundDevices.map(\.vzConfiguration)
-    }
-
-    var vzPointingDevices: [VZPointingDeviceConfiguration] {
-        get throws { try hardware.pointingDevice.vzConfigurations }
-    }
-
-    var vzGraphicsDevices: [VZGraphicsDeviceConfiguration] {
-        let graphicsConfiguration = VZMacGraphicsDeviceConfiguration()
-
-        graphicsConfiguration.displays = vzDisplays
-
-        return [graphicsConfiguration]
-    }
-
-}
 
 extension VBDisplayDevice {
 
@@ -95,141 +36,4 @@ extension VBDisplayDevice {
         VZMacGraphicsDisplayConfiguration(widthInPixels: width, heightInPixels: height, pixelsPerInch: pixelsPerInch)
     }
 
-}
-
-extension VBNetworkDevice {
-
-    var vzConfiguration: VZNetworkDeviceConfiguration {
-        get throws {
-            let config = VZVirtioNetworkDeviceConfiguration()
-
-            guard let addr = VZMACAddress(string: macAddress) else {
-                throw Failure("Invalid MAC address")
-            }
-
-            config.macAddress = addr
-            config.attachment = try vzAttachment
-
-            return config
-        }
-    }
-
-    private var vzAttachment: VZNetworkDeviceAttachment {
-        get throws {
-            switch kind {
-            case .NAT:
-                return VZNATNetworkDeviceAttachment()
-            case .bridge:
-                let interface = try resolveBridge(with: id)
-                return VZBridgedNetworkDeviceAttachment(interface: interface)
-            }
-        }
-    }
-
-    private func resolveBridge(with identifier: String) throws -> VZBridgedNetworkInterface {
-        guard let iface = VZBridgedNetworkInterface.networkInterfaces.first(where: { $0.identifier == identifier }) else {
-            throw Failure("Couldn't find the specified network interface for bridging")
-        }
-        return iface
-    }
-
-}
-
-extension VBPointingDevice {
-
-    var vzConfigurations: [VZPointingDeviceConfiguration] {
-        get throws {
-            switch kind {
-            case .mouse:
-                return [VZUSBScreenCoordinatePointingDeviceConfiguration()]
-            case .trackpad:
-                guard #available(macOS 13.0, *) else {
-                    throw Failure("The trackpad pointing device is only available on macOS 13 and later")
-                }
-                return [
-                    VZMacTrackpadConfiguration(),
-                    VZUSBScreenCoordinatePointingDeviceConfiguration()
-                ]
-            }
-        }
-    }
-
-}
-
-extension VBSoundDevice {
-
-    var vzConfiguration: VZAudioDeviceConfiguration {
-        let audioConfiguration = VZVirtioSoundDeviceConfiguration()
-
-        if enableInput {
-            let inputStream = VZVirtioSoundDeviceInputStreamConfiguration()
-            inputStream.source = VZHostAudioInputStreamSource()
-            audioConfiguration.streams.append(inputStream)
-        }
-
-        if enableOutput {
-            let outputStream = VZVirtioSoundDeviceOutputStreamConfiguration()
-            outputStream.sink = VZHostAudioOutputStreamSink()
-            audioConfiguration.streams.append(outputStream)
-        }
-
-        return audioConfiguration
-    }
-
-}
-
-extension VBMacConfiguration {
-    
-    @available(macOS 13.0, *)
-    var vzClipboardSyncDevice: VZVirtioConsoleDeviceConfiguration? {
-        #if ENABLE_SPICE_CLIPBOARD_SYNC
-        let device = VZVirtioConsoleDeviceConfiguration()
-        
-        let port = VZVirtioConsolePortConfiguration()
-        port.name = VZSpiceAgentPortAttachment.spiceAgentPortName
-        let attachment = VZSpiceAgentPortAttachment()
-        attachment.sharesClipboard = sharedClipboardEnabled
-        port.attachment = attachment
-        device.ports[0] = port
-        
-        print("attachment.sharesClipboard = \(attachment.sharesClipboard)")
-        
-        return device
-        #else
-        return nil
-        #endif
-    }
-    
-}
-
-extension VBMacConfiguration {
-    
-    var vzSharedFoldersFileSystemDevices: [VZDirectorySharingDeviceConfiguration] {
-        get throws {
-            var directories: [String: VZSharedDirectory] = [:]
-            
-            for folder in sharedFolders {
-                guard let dir = folder.vzSharedFolder else { continue }
-                
-                directories[folder.effectiveMountPointName] = dir
-            }
-            
-            try VZVirtioFileSystemDeviceConfiguration.validateTag(VBSharedFolder.virtualBuddyShareName)
-            
-            let share = VZMultipleDirectoryShare(directories: directories)
-            let device = VZVirtioFileSystemDeviceConfiguration(tag: VBSharedFolder.virtualBuddyShareName)
-            device.share = share
-            return [device]
-        }
-    }
-    
-}
-
-extension VBSharedFolder {
-    
-    var vzSharedFolder: VZSharedDirectory? {
-        guard isAvailable, isEnabled else { return nil }
-        return VZSharedDirectory(url: url, readOnly: isReadOnly)
-    }
-    
 }

--- a/VirtualCore/Source/Virtualization/Helpers/VirtualMachineConfigurationHelper.swift
+++ b/VirtualCore/Source/Virtualization/Helpers/VirtualMachineConfigurationHelper.swift
@@ -1,0 +1,218 @@
+/*
+See LICENSE folder for this sample’s licensing information.
+
+Abstract:
+Helper that creates various configuration objects exposed in the `VZVirtualMachineConfiguration`.
+*/
+
+import Foundation
+import Virtualization
+
+protocol VirtualMachineConfigurationHelper {
+    var vm: VBVirtualMachine { get }
+    func createInstallDevice(installImageURL: URL) throws -> VZStorageDeviceConfiguration
+    func createBootLoader() -> VZBootLoader
+    func createBootBlockDevice() async throws -> VZVirtioBlockDeviceConfiguration
+    func createAdditionalBlockDevices() async throws -> [VZVirtioBlockDeviceConfiguration]
+    func createKeyboardConfiguration() -> VZKeyboardConfiguration
+    func createGraphicsDevices() -> [VZGraphicsDeviceConfiguration]
+}
+
+extension VirtualMachineConfigurationHelper {
+
+    func createBootBlockDevice() async throws -> VZVirtioBlockDeviceConfiguration {
+        do {
+            let bootDevice = try vm.bootDevice
+            let bootDiskImage = try vm.bootDiskImage
+            
+            if !bootDevice.diskImageExists(for: vm) {
+                let settings = DiskImageGenerator.ImageSettings(for: bootDiskImage, in: vm)
+                try await DiskImageGenerator.generateImage(with: settings)
+            }
+
+            let bootURL = vm.diskImageURL(for: bootDiskImage)
+            let diskImageAttachment = try VZDiskImageStorageDeviceAttachment(url: bootURL, readOnly: false)
+
+            let disk = VZVirtioBlockDeviceConfiguration(attachment: diskImageAttachment)
+
+            return disk
+        } catch {
+            throw Failure("Failed to instantiate a disk image for the VM: \(error.localizedDescription).")
+        }
+    }
+    
+    func createAdditionalBlockDevices() async throws -> [VZVirtioBlockDeviceConfiguration] {
+        var output = [VZVirtioBlockDeviceConfiguration]()
+
+        for device in vm.configuration.hardware.storageDevices {
+            guard device.isEnabled, !device.isBootVolume else { continue }
+            
+            let url = vm.diskImageURL(for: device)
+            let attachment = try VZDiskImageStorageDeviceAttachment(url: url, readOnly: device.isReadOnly)
+
+            output.append(VZVirtioBlockDeviceConfiguration(attachment: attachment))
+        }
+
+        return output
+    }
+
+    func createKeyboardConfiguration() -> VZKeyboardConfiguration {
+        return VZUSBKeyboardConfiguration()
+    }
+
+}
+
+extension VBMacConfiguration {
+
+    var vzNetworkDevices: [VZNetworkDeviceConfiguration] {
+        get throws {
+            try hardware.networkDevices.map { try $0.vzConfiguration }
+        }
+    }
+
+    var vzAudioDevices: [VZAudioDeviceConfiguration] {
+        hardware.soundDevices.map(\.vzConfiguration)
+    }
+
+    var vzPointingDevices: [VZPointingDeviceConfiguration] {
+        get throws { try hardware.pointingDevice.vzConfigurations }
+    }
+
+}
+
+extension VBNetworkDevice {
+
+    var vzConfiguration: VZNetworkDeviceConfiguration {
+        get throws {
+            let config = VZVirtioNetworkDeviceConfiguration()
+
+            guard let addr = VZMACAddress(string: macAddress) else {
+                throw Failure("Invalid MAC address")
+            }
+
+            config.macAddress = addr
+            config.attachment = try vzAttachment
+
+            return config
+        }
+    }
+
+    private var vzAttachment: VZNetworkDeviceAttachment {
+        get throws {
+            switch kind {
+            case .NAT:
+                return VZNATNetworkDeviceAttachment()
+            case .bridge:
+                let interface = try resolveBridge(with: id)
+                return VZBridgedNetworkDeviceAttachment(interface: interface)
+            }
+        }
+    }
+
+    private func resolveBridge(with identifier: String) throws -> VZBridgedNetworkInterface {
+        guard let iface = VZBridgedNetworkInterface.networkInterfaces.first(where: { $0.identifier == identifier }) else {
+            throw Failure("Couldn't find the specified network interface for bridging")
+        }
+        return iface
+    }
+
+}
+
+extension VBPointingDevice {
+
+    var vzConfigurations: [VZPointingDeviceConfiguration] {
+        get throws {
+            switch kind {
+            case .mouse:
+                return [VZUSBScreenCoordinatePointingDeviceConfiguration()]
+            case .trackpad:
+                guard #available(macOS 13.0, *) else {
+                    throw Failure("The trackpad pointing device is only available on macOS 13 and later")
+                }
+                return [
+                    VZMacTrackpadConfiguration(),
+                    VZUSBScreenCoordinatePointingDeviceConfiguration()
+                ]
+            }
+        }
+    }
+
+}
+
+extension VBSoundDevice {
+
+    var vzConfiguration: VZAudioDeviceConfiguration {
+        let audioConfiguration = VZVirtioSoundDeviceConfiguration()
+
+        if enableInput {
+            let inputStream = VZVirtioSoundDeviceInputStreamConfiguration()
+            inputStream.source = VZHostAudioInputStreamSource()
+            audioConfiguration.streams.append(inputStream)
+        }
+
+        if enableOutput {
+            let outputStream = VZVirtioSoundDeviceOutputStreamConfiguration()
+            outputStream.sink = VZHostAudioOutputStreamSink()
+            audioConfiguration.streams.append(outputStream)
+        }
+
+        return audioConfiguration
+    }
+
+}
+
+extension VBMacConfiguration {
+    
+    @available(macOS 13.0, *)
+    var vzClipboardSyncDevice: VZVirtioConsoleDeviceConfiguration? {
+        #if ENABLE_SPICE_CLIPBOARD_SYNC
+        let device = VZVirtioConsoleDeviceConfiguration()
+        
+        let port = VZVirtioConsolePortConfiguration()
+        port.name = VZSpiceAgentPortAttachment.spiceAgentPortName
+        let attachment = VZSpiceAgentPortAttachment()
+        attachment.sharesClipboard = sharedClipboardEnabled
+        port.attachment = attachment
+        device.ports[0] = port
+        
+        print("attachment.sharesClipboard = \(attachment.sharesClipboard)")
+        
+        return device
+        #else
+        return nil
+        #endif
+    }
+    
+}
+
+extension VBMacConfiguration {
+    
+    var vzSharedFoldersFileSystemDevices: [VZDirectorySharingDeviceConfiguration] {
+        get throws {
+            var directories: [String: VZSharedDirectory] = [:]
+            
+            for folder in sharedFolders {
+                guard let dir = folder.vzSharedFolder else { continue }
+                
+                directories[folder.effectiveMountPointName] = dir
+            }
+            
+            try VZVirtioFileSystemDeviceConfiguration.validateTag(VBSharedFolder.virtualBuddyShareName)
+            
+            let share = VZMultipleDirectoryShare(directories: directories)
+            let device = VZVirtioFileSystemDeviceConfiguration(tag: VBSharedFolder.virtualBuddyShareName)
+            device.share = share
+            return [device]
+        }
+    }
+    
+}
+
+extension VBSharedFolder {
+    
+    var vzSharedFolder: VZSharedDirectory? {
+        guard isAvailable, isEnabled else { return nil }
+        return VZSharedDirectory(url: url, readOnly: isReadOnly)
+    }
+    
+}

--- a/VirtualCore/Source/Virtualization/Helpers/VirtualMachineConfigurationHelper.swift
+++ b/VirtualCore/Source/Virtualization/Helpers/VirtualMachineConfigurationHelper.swift
@@ -11,7 +11,7 @@ import Virtualization
 protocol VirtualMachineConfigurationHelper {
     var vm: VBVirtualMachine { get }
     func createInstallDevice(installImageURL: URL) throws -> VZStorageDeviceConfiguration
-    func createBootLoader() -> VZBootLoader
+    func createBootLoader() throws -> VZBootLoader
     func createBootBlockDevice() async throws -> VZVirtioBlockDeviceConfiguration
     func createAdditionalBlockDevices() async throws -> [VZVirtioBlockDeviceConfiguration]
     func createKeyboardConfiguration() -> VZKeyboardConfiguration

--- a/VirtualCore/Source/Virtualization/VMController.swift
+++ b/VirtualCore/Source/Virtualization/VMController.swift
@@ -14,6 +14,9 @@ import OSLog
 public struct VMSessionOptions: Hashable, Codable {
     public var bootInRecoveryMode = false
     
+    @DecodableDefault.False
+    public var bootOnInstallDevice = false
+    
     public static let `default` = VMSessionOptions()
 }
 
@@ -52,6 +55,9 @@ public final class VMController: ObservableObject {
     public init(with vm: VBVirtualMachine) {
         self.virtualMachineModel = vm
         virtualMachineModel.reloadMetadata()
+        if virtualMachineModel.metadata.installImageURL != nil && !virtualMachineModel.metadata.installFinished {
+            options.bootOnInstallDevice = true
+        }
 
         /// Ensure configuration is persisted whenever it changes.
         $virtualMachineModel
@@ -92,6 +98,7 @@ public final class VMController: ObservableObject {
             let vm = try newInstance.virtualMachine
             
             state = .running(vm)
+            virtualMachineModel.metadata.installFinished = true
         } catch {
             state = .stopped(error)
         }

--- a/VirtualCore/Source/Virtualization/VMInstance.swift
+++ b/VirtualCore/Source/Virtualization/VMInstance.swift
@@ -92,17 +92,42 @@ public final class VMInstance: NSObject, ObservableObject {
         return macPlatform
     }
 
+    @available(macOS 13.0, *)
+    public static func createGenericPlatform(for model: VBVirtualMachine, installImageURL: URL?) async throws -> VZGenericPlatformConfiguration {
+        let genericPlatform = VZGenericPlatformConfiguration()
+        return genericPlatform
+    }
+
     // MARK: Create the Virtual Machine Configuration and instantiate the Virtual Machine
 
     public static func makeConfiguration(for model: VBVirtualMachine, installImageURL: URL? = nil) async throws -> VZVirtualMachineConfiguration {
-        let helper = MacOSVirtualMachineConfigurationHelper(vm: model)
+        let helper: VirtualMachineConfigurationHelper
+        let platform: VZPlatformConfiguration
+        let installDevice: [VZStorageDeviceConfiguration]
+        switch model.configuration.systemType {
+        case .mac:
+            helper = MacOSVirtualMachineConfigurationHelper(vm: model)
+            platform = try await Self.createMacPlaform(for: model, installImageURL: installImageURL)
+            installDevice = []
+        case .linux:
+            guard #available(macOS 13.0, *) else {
+                throw Failure("This configuration requires macOS 13")
+            }
+            helper = LinuxVirtualMachineConfigurationHelper(vm: model)
+            platform = try await Self.createGenericPlatform(for: model, installImageURL: nil)
+            if let installImageURL {
+                installDevice = [try helper.createInstallDevice(installImageURL: installImageURL)]
+            } else {
+                installDevice = []
+            }
+        }
         let c = VZVirtualMachineConfiguration()
 
-        c.platform = try await Self.createMacPlaform(for: model, installImageURL: installImageURL)
+        c.platform = platform
         c.bootLoader = helper.createBootLoader()
         c.cpuCount = model.configuration.hardware.cpuCount
         c.memorySize = model.configuration.hardware.memorySize
-        c.graphicsDevices = model.configuration.vzGraphicsDevices
+        c.graphicsDevices = helper.createGraphicsDevices()
         c.networkDevices = try model.configuration.vzNetworkDevices
         c.pointingDevices = try model.configuration.vzPointingDevices
         c.keyboards = [helper.createKeyboardConfiguration()]
@@ -116,13 +141,19 @@ public final class VMInstance: NSObject, ObservableObject {
         let bootDevice = try await helper.createBootBlockDevice()
         let additionalBlockDevices = try await helper.createAdditionalBlockDevices()
 
-        c.storageDevices = [bootDevice] + additionalBlockDevices
+        c.storageDevices = installDevice + [bootDevice] + additionalBlockDevices
         
         return c
     }
     
     private func createVirtualMachine() async throws {
-        let config = try await Self.makeConfiguration(for: virtualMachineModel)
+        let installImage: URL?
+        if options.bootOnInstallDevice, #available(macOS 13.0, *) {
+            installImage = virtualMachineModel.metadata.installImageURL
+        } else {
+            installImage = nil
+        }
+        let config = try await Self.makeConfiguration(for: virtualMachineModel, installImageURL: installImage) // add install iso here for linux (hack)
 
         do {
             try config.validate()
@@ -151,9 +182,7 @@ public final class VMInstance: NSObject, ObservableObject {
         hookingPoint?.hook()
 
         if #available(macOS 13, *) {
-            let opts = VZMacOSVirtualMachineStartOptions()
-            opts.startUpFromMacOSRecovery = options.bootInRecoveryMode
-            try await vm.start(options: opts)
+            try await vm.start(options: startOptions)
         } else {
             let opts = _VZVirtualMachineStartOptions()
             opts.bootMacOSRecovery = options.bootInRecoveryMode
@@ -161,6 +190,18 @@ public final class VMInstance: NSObject, ObservableObject {
         }
 
         VMLibraryController.shared.bootedMachineIdentifiers.insert(self.virtualMachineModel.id)
+    }
+    
+    @available(macOS 13, *)
+    private var startOptions: VZVirtualMachineStartOptions {
+        switch virtualMachineModel.configuration.systemType {
+        case .mac:
+            let opts = VZMacOSVirtualMachineStartOptions()
+            opts.startUpFromMacOSRecovery = options.bootInRecoveryMode
+            return opts
+        case .linux:
+            return VZVirtualMachineStartOptions()
+        }
     }
     
     func pause() async throws {

--- a/VirtualCore/Source/Virtualization/VMInstance.swift
+++ b/VirtualCore/Source/Virtualization/VMInstance.swift
@@ -124,7 +124,7 @@ public final class VMInstance: NSObject, ObservableObject {
         let c = VZVirtualMachineConfiguration()
 
         c.platform = platform
-        c.bootLoader = helper.createBootLoader()
+        c.bootLoader = try helper.createBootLoader()
         c.cpuCount = model.configuration.hardware.cpuCount
         c.memorySize = model.configuration.hardware.memorySize
         c.graphicsDevices = helper.createGraphicsDevices()

--- a/VirtualUI/Source/Installer/Steps/InstallMethodPicker.swift
+++ b/VirtualUI/Source/Installer/Steps/InstallMethodPicker.swift
@@ -17,7 +17,10 @@ enum InstallMethod: String, Identifiable, CaseIterable, CustomStringConvertible 
     var description: String {
         switch self {
             case .localFile:
-                return "Open custom IPSW file from local storage"
+                guard #available(macOS 13, *) else {
+                    return "Open custom IPSW file from local storage"
+                }
+            return "Open custom IPSW or ISO file from local storage"
             case .remoteOptions:
                 return "Download macOS installer from a list of options"
             case .remoteManual:

--- a/VirtualUI/Source/Installer/VMInstallationWizard.swift
+++ b/VirtualUI/Source/Installer/VMInstallationWizard.swift
@@ -106,7 +106,7 @@ public struct VMInstallationWizard: View {
     @ViewBuilder
     private var configureVM: some View {
         VStack {
-            InstallationWizardTitle("Configure Your Virtual Mac")
+            InstallationWizardTitle("Configure Your Virtual Machine")
 
             if let machine = viewModel.machine {
                 InstallConfigurationStepView(vm: machine) { configuredModel in
@@ -124,7 +124,7 @@ public struct VMInstallationWizard: View {
     @ViewBuilder
     private var renameVM: some View {
         VStack {
-            InstallationWizardTitle("Name Your Virtual Mac")
+            InstallationWizardTitle("Name Your Virtual Machine")
 
             VirtualMachineNameField(name: $viewModel.data.name, onCommit: viewModel.goNext)
         }
@@ -164,7 +164,7 @@ public struct VMInstallationWizard: View {
         VStack {
             InstallationWizardTitle(vmDisplayName)
 
-            Text("Your virtual Mac is ready!")
+            Text("Your virtual machine is ready!")
         }
     }
 

--- a/VirtualUI/Source/Session/Configuration/VMSessionConfigurationView.swift
+++ b/VirtualUI/Source/Session/Configuration/VMSessionConfigurationView.swift
@@ -16,9 +16,17 @@ struct VMSessionConfigurationView: View {
     var body: some View {
         VStack(alignment: .trailing) {
             Group {
-                HStack {
-                    Text("Boot in recovery mode")
-                    Toggle("Boot in recovery mode", isOn: $controller.options.bootInRecoveryMode)
+                if showInstallDeviceOption {
+                    HStack {
+                        Text("Boot on install drive")
+                        Toggle("Boot on install drive", isOn: $controller.options.bootOnInstallDevice)
+                    }
+                }
+                if showRecoveryModeOption {
+                    HStack {
+                        Text("Boot in recovery mode")
+                        Toggle("Boot in recovery mode", isOn: $controller.options.bootInRecoveryMode)
+                    }
                 }
                 HStack {
                     Text("Capture system keyboard shortcuts")
@@ -43,6 +51,14 @@ struct VMSessionConfigurationView: View {
             )
             .environmentObject(VMConfigurationViewModel(controller.virtualMachineModel))
         }
+    }
+    
+    private var showInstallDeviceOption: Bool {
+        controller.virtualMachineModel.metadata.installImageURL != nil
+    }
+    
+    private var showRecoveryModeOption: Bool {
+        controller.virtualMachineModel.configuration.systemType == .mac
     }
 }
 


### PR DESCRIPTION
This update allows to install and boot from some ARM-based Linux distributions (tested successfully with many versions of Ubuntu -- couldn't make it work with CentOS so far.)

The option is visible only when available (macOS 13+)

To install a Linux system:
- choose the first install method ("Open custom IPSW or ISO file from local storage)
- select .iso file and configure the VM
- start the VM with the "Boot on install drive" option enabled
- proceed with Linux installation
- when Linux is installed, close the VM and restart it (the "Boot on install drive" option should be off)
- enjoy!

Some classes/structs need to be renamed (VBMacConfiguration etc). I chose to keep them unmodified for now in order not to add too much noise to this MR.