### PR TITLE
Implemented options to resize window according to VM display resolution

### DIFF
--- a/VirtualBuddy.xcodeproj/project.pbxproj
+++ b/VirtualBuddy.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		F498AD182884C593006F1C00 /* NumericPropertyControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = F498AD172884C593006F1C00 /* NumericPropertyControl.swift */; };
 		F498AD1A2884C5FF006F1C00 /* SliderConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F498AD192884C5FF006F1C00 /* SliderConversion.swift */; };
 		F49A68E12884917E00A17582 /* ConfigurationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49A68E02884917E00A17582 /* ConfigurationModels.swift */; };
+		F49AA2C329BA22A5009625F7 /* VBRestorableWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49AA2C229BA22A5009625F7 /* VBRestorableWindow.swift */; };
 		F4A21BF228032FD8001072B8 /* VMLibraryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A21BF128032FD8001072B8 /* VMLibraryController.swift */; };
 		F4A21BF428033102001072B8 /* VBError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A21BF328033102001072B8 /* VBError.swift */; };
 		F4B5C5D32886FA8D005AA632 /* SharedFoldersManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B5C5D22886FA8D005AA632 /* SharedFoldersManagementView.swift */; };
@@ -270,6 +271,7 @@
 		F498AD172884C593006F1C00 /* NumericPropertyControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumericPropertyControl.swift; sourceTree = "<group>"; };
 		F498AD192884C5FF006F1C00 /* SliderConversion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SliderConversion.swift; sourceTree = "<group>"; };
 		F49A68E02884917E00A17582 /* ConfigurationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationModels.swift; sourceTree = "<group>"; };
+		F49AA2C229BA22A5009625F7 /* VBRestorableWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VBRestorableWindow.swift; sourceTree = "<group>"; };
 		F4A21BF128032FD8001072B8 /* VMLibraryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMLibraryController.swift; sourceTree = "<group>"; };
 		F4A21BF328033102001072B8 /* VBError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VBError.swift; sourceTree = "<group>"; };
 		F4B068B428882EB7003743BF /* VirtualBuddy_Managed.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VirtualBuddy_Managed.entitlements; sourceTree = "<group>"; };
@@ -383,6 +385,7 @@
 				F41725672886E5AD004FF8A7 /* MaterialView.swift */,
 				F41725652886DF58004FF8A7 /* OpenSavePanelUtils.swift */,
 				F42C014B2888C34B00EB15CD /* LogConsole.swift */,
+				F49AA2C229BA22A5009625F7 /* VBRestorableWindow.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1184,6 +1187,7 @@
 				F422587C2885E1CE009420AE /* NetworkConfigurationView.swift in Sources */,
 				F48E0D1F288882BD0080DDFA /* VMInstallationViewModel.swift in Sources */,
 				F42258702885D537009420AE /* EphemeralTextField.swift in Sources */,
+				F49AA2C329BA22A5009625F7 /* VBRestorableWindow.swift in Sources */,
 				F422587A2885E17D009420AE /* ConfigurationSection.swift in Sources */,
 				F4B5C5D32886FA8D005AA632 /* SharedFoldersManagementView.swift in Sources */,
 				F48E0D32288884A10080DDFA /* RestoreImageDownloadView.swift in Sources */,

--- a/VirtualBuddy.xcodeproj/project.pbxproj
+++ b/VirtualBuddy.xcodeproj/project.pbxproj
@@ -82,6 +82,8 @@
 		F498AD1A2884C5FF006F1C00 /* SliderConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F498AD192884C5FF006F1C00 /* SliderConversion.swift */; };
 		F49A68E12884917E00A17582 /* ConfigurationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49A68E02884917E00A17582 /* ConfigurationModels.swift */; };
 		F49AA2C329BA22A5009625F7 /* VBRestorableWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49AA2C229BA22A5009625F7 /* VBRestorableWindow.swift */; };
+		F49AA2C529BA31CC009625F7 /* VirtualMachineSessionUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49AA2C429BA31CC009625F7 /* VirtualMachineSessionUI.swift */; };
+		F49AA2C729BA3F2B009625F7 /* VBRestorableWindow+Resizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49AA2C629BA3F2B009625F7 /* VBRestorableWindow+Resizing.swift */; };
 		F4A21BF228032FD8001072B8 /* VMLibraryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A21BF128032FD8001072B8 /* VMLibraryController.swift */; };
 		F4A21BF428033102001072B8 /* VBError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A21BF328033102001072B8 /* VBError.swift */; };
 		F4B5C5D32886FA8D005AA632 /* SharedFoldersManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B5C5D22886FA8D005AA632 /* SharedFoldersManagementView.swift */; };
@@ -272,6 +274,8 @@
 		F498AD192884C5FF006F1C00 /* SliderConversion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SliderConversion.swift; sourceTree = "<group>"; };
 		F49A68E02884917E00A17582 /* ConfigurationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationModels.swift; sourceTree = "<group>"; };
 		F49AA2C229BA22A5009625F7 /* VBRestorableWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VBRestorableWindow.swift; sourceTree = "<group>"; };
+		F49AA2C429BA31CC009625F7 /* VirtualMachineSessionUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualMachineSessionUI.swift; sourceTree = "<group>"; };
+		F49AA2C629BA3F2B009625F7 /* VBRestorableWindow+Resizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VBRestorableWindow+Resizing.swift"; sourceTree = "<group>"; };
 		F4A21BF128032FD8001072B8 /* VMLibraryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMLibraryController.swift; sourceTree = "<group>"; };
 		F4A21BF328033102001072B8 /* VBError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VBError.swift; sourceTree = "<group>"; };
 		F4B068B428882EB7003743BF /* VirtualBuddy_Managed.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VirtualBuddy_Managed.entitlements; sourceTree = "<group>"; };
@@ -385,7 +389,6 @@
 				F41725672886E5AD004FF8A7 /* MaterialView.swift */,
 				F41725652886DF58004FF8A7 /* OpenSavePanelUtils.swift */,
 				F42C014B2888C34B00EB15CD /* LogConsole.swift */,
-				F49AA2C229BA22A5009625F7 /* VBRestorableWindow.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -458,6 +461,7 @@
 			children = (
 				F42C01562888FC0C00EB15CD /* Components */,
 				F42C01532888FC0C00EB15CD /* Configuration */,
+				F49AA2C429BA31CC009625F7 /* VirtualMachineSessionUI.swift */,
 				F42C01552888FC0C00EB15CD /* VirtualMachineSessionView.swift */,
 			);
 			path = Session;
@@ -552,6 +556,8 @@
 				F48E0D27288883150080DDFA /* OpenCocoaWindowAction.swift */,
 				F48E0D28288883150080DDFA /* HostingWindowController.swift */,
 				F48E0D29288883150080DDFA /* WindowEnvironment.swift */,
+				F49AA2C229BA22A5009625F7 /* VBRestorableWindow.swift */,
+				F49AA2C629BA3F2B009625F7 /* VBRestorableWindow+Resizing.swift */,
 			);
 			path = HostingWindowController;
 			sourceTree = "<group>";
@@ -1147,6 +1153,7 @@
 				F422587E2885E2ED009420AE /* HardwareConfigurationView.swift in Sources */,
 				F48E0D1D288882BD0080DDFA /* AuthenticatingWebView.swift in Sources */,
 				F4561A6828981B4100055289 /* VirtualMachineNameField.swift in Sources */,
+				F49AA2C529BA31CC009625F7 /* VirtualMachineSessionUI.swift in Sources */,
 				F48E0D34288889E60080DDFA /* InstallConfigurationStepView.swift in Sources */,
 				F42C015B2888FC0C00EB15CD /* VMSessionConfigurationView.swift in Sources */,
 				F42C015D2888FC0C00EB15CD /* SwiftUIVMView.swift in Sources */,
@@ -1158,6 +1165,7 @@
 				F417255B2884D79C004FF8A7 /* FixSwiftUIMaterialInPreviews.m in Sources */,
 				F48E0D03288858E00080DDFA /* ManagedDiskImageEditor.swift in Sources */,
 				F42C015A2888FC0C00EB15CD /* LibraryView.swift in Sources */,
+				F49AA2C729BA3F2B009625F7 /* VBRestorableWindow+Resizing.swift in Sources */,
 				F4E7680A29B64C590075A897 /* GuestTypePicker.swift in Sources */,
 				F4B5C5DB28873628005AA632 /* GroupedList.swift in Sources */,
 				F417256C2887500F004FF8A7 /* StorageConfigurationView.swift in Sources */,

--- a/VirtualBuddy/Bootstrap/VirtualBuddyApp.swift
+++ b/VirtualBuddy/Bootstrap/VirtualBuddyApp.swift
@@ -7,19 +7,24 @@
 
 import SwiftUI
 import VirtualCore
+import VirtualUI
 
 @main
 struct VirtualBuddyApp: App {
     @NSApplicationDelegateAdaptor
     var appDelegate: VirtualBuddyAppDelegate
 
-    @StateObject var settingsContainer = VBSettingsContainer.current
-    @StateObject var updateController = SoftwareUpdateController.shared
-    
+    @StateObject private var settingsContainer = VBSettingsContainer.current
+    @StateObject private var updateController = SoftwareUpdateController.shared
+    @StateObject private var library = VMLibraryController.shared
+    @StateObject private var sessionManager = VirtualMachineSessionUIManager.shared
+
     var body: some Scene {
         WindowGroup {
             LibraryView()
                 .onAppearOnce(perform: updateController.activate)
+                .environmentObject(library)
+                .environmentObject(sessionManager)
         }
         .windowToolbarStyle(.unified)
         .commands {
@@ -30,6 +35,11 @@ struct VirtualBuddyApp: App {
                 }
             }
             #endif
+
+            CommandGroup(before: .windowSize) {
+                VirtualMachineWindowCommands()
+                    .environmentObject(sessionManager)
+            }
         }
         
         Settings {

--- a/VirtualCore/Source/Virtualization/VMLibraryController.swift
+++ b/VirtualCore/Source/Virtualization/VMLibraryController.swift
@@ -30,7 +30,7 @@ public final class VMLibraryController: ObservableObject {
     
     @Published public private(set) var virtualMachines: [VBVirtualMachine] = []
 
-    @Published public internal(set) var bootedMachineIdentifiers = Set<VBVirtualMachine.ID>()
+    @Published public internal(set) var bootedMachineIdentifiers = Set<VBVirtualMachine.ID>()    
     
     public static let shared = VMLibraryController()
 

--- a/VirtualUI/Source/Components/HostingWindowController/HostingWindowController.swift
+++ b/VirtualUI/Source/Components/HostingWindowController/HostingWindowController.swift
@@ -26,8 +26,12 @@ public final class HostingWindowController<Content>: NSWindowController, NSWindo
         )
     }
 
-    public init(rootView: Content, windowFactory: (() -> NSWindow)? = nil) {
+    public init(id: String? = nil, rootView: Content, windowFactory: (() -> NSWindow)? = nil) {
         let window = windowFactory?() ?? Self.makeDefaultWindow()
+
+        if let id {
+            window.identifier = .init(id)
+        }
         
         super.init(window: window)
 
@@ -120,7 +124,7 @@ protocol WindowChromeConsumer: AnyObject {
     var confirmBeforeClosingCallback: () async -> Bool { get set }
 }
 
-fileprivate final class HostingWindow: NSWindow {
+fileprivate final class HostingWindow: VBRestorableWindow {
     
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { true }
@@ -138,5 +142,5 @@ fileprivate final class HostingWindow: NSWindow {
     private func closeWithoutConfirmation() {
         super.close()
     }
-    
+
 }

--- a/VirtualUI/Source/Components/HostingWindowController/OpenCocoaWindowAction.swift
+++ b/VirtualUI/Source/Components/HostingWindowController/OpenCocoaWindowAction.swift
@@ -95,7 +95,7 @@ public struct OpenCocoaWindowAction {
         if let existingController = manager[token] {
             existingController.showWindow(nil)
         } else {
-            let controller = HostingWindowController(rootView: content())
+            let controller = HostingWindowController(id: id, rootView: content())
 
             manager[token] = controller
         }

--- a/VirtualUI/Source/Components/HostingWindowController/VBRestorableWindow+Resizing.swift
+++ b/VirtualUI/Source/Components/HostingWindowController/VBRestorableWindow+Resizing.swift
@@ -1,0 +1,84 @@
+//
+//  VBRestorableWindow+Resizing.swift
+//  VirtualUI
+//
+//  Created by Guilherme Rambo on 09/03/23.
+//
+
+import Cocoa
+import AVFoundation
+import VirtualCore
+
+extension VBRestorableWindow {
+
+    func resize(to size: VirtualMachineSessionUI.WindowSize, for display: VBDisplayDevice) {
+        guard let screen else { return }
+
+        let targetSize: CGSize
+        let displaySize = CGSize(width: display.width, height: display.height)
+        let availableHeight: CGFloat = screen.visibleFrame.height - screen.visibleFrame.origin.y / 2
+
+        switch size {
+        case .pointAccurate:
+            targetSize = CGSize(
+                width: CGFloat(display.width) * 72.0 / CGFloat(display.pixelsPerInch),
+                height: CGFloat(display.height) * 72.0 / CGFloat(display.pixelsPerInch)
+            )
+        case .pixelAccurate:
+            targetSize = CGSize(
+                width: CGFloat(display.width) * screen.dpi.width / CGFloat(display.pixelsPerInch),
+                height: CGFloat(display.height) * screen.dpi.height / CGFloat(display.pixelsPerInch)
+            )
+        case .fitScreen:
+            let windowAspectRatio = displaySize.width / displaySize.height
+            let containerAspectRatio = screen.visibleFrame.width / availableHeight
+            let widthFirst = windowAspectRatio > containerAspectRatio
+
+            let windowWidth: CGFloat
+            let windowHeight: CGFloat
+
+            if widthFirst {
+                windowWidth = screen.visibleFrame.width
+                windowHeight = windowWidth / windowAspectRatio
+            } else {
+                windowHeight = availableHeight
+                windowWidth = windowHeight * windowAspectRatio
+            }
+
+            targetSize = CGSize(width: windowWidth, height: windowHeight)
+        }
+
+        let targetRect = NSRect(
+            x: screen.visibleFrame.origin.x + screen.visibleFrame.width / 2 - targetSize.width / 2,
+            y: screen.visibleFrame.origin.y + availableHeight / 2 - targetSize.height / 2,
+            width: targetSize.width,
+            height: targetSize.height
+        )
+
+        let frameRect = frameRect(forContentRect: targetRect)
+
+        withFrameConstraintsDisabled(size != .fitScreen) {
+            setFrame(frameRect, display: true)
+        }
+    }
+
+    func applyAspectRatio(_ ratio: CGSize?) {
+        guard let ratio else {
+            resizeIncrements = CGSize(width: 1, height: 1)
+            return
+        }
+
+        aspectRatio = ratio
+
+        let newFrame = frameRect(forContentRect: AVMakeRect(aspectRatio: ratio, insideRect: frame))
+
+        setFrame(newFrame, display: true)
+    }
+
+}
+
+extension NSScreen {
+    var dpi: CGSize {
+        (deviceDescription[NSDeviceDescriptionKey.resolution] as? CGSize) ?? CGSize(width: 72.0, height: 72.0)
+    }
+}

--- a/VirtualUI/Source/Components/HostingWindowController/VBRestorableWindow.swift
+++ b/VirtualUI/Source/Components/HostingWindowController/VBRestorableWindow.swift
@@ -65,4 +65,28 @@ class VBRestorableWindow: NSWindow {
         UserDefaults.standard.synchronize()
     }
 
+    private var frameConstraintsDisabled = false
+
+    func withFrameConstraintsDisabled(_ disabled: Bool = true, perform block: () -> Void) {
+        NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(resetConstraintsDisabledFlag), object: nil)
+
+        frameConstraintsDisabled = disabled
+
+        block()
+
+        perform(#selector(resetConstraintsDisabledFlag), with: nil, afterDelay: 0.2)
+    }
+
+    override func constrainFrameRect(_ frameRect: NSRect, to screen: NSScreen?) -> NSRect {
+        guard frameConstraintsDisabled else {
+            return super.constrainFrameRect(frameRect, to: screen)
+        }
+
+        return frameRect
+    }
+
+    @objc private func resetConstraintsDisabledFlag() {
+        frameConstraintsDisabled = false
+    }
+
 }

--- a/VirtualUI/Source/Components/VBRestorableWindow.swift
+++ b/VirtualUI/Source/Components/VBRestorableWindow.swift
@@ -1,0 +1,55 @@
+//
+//  VBRestorableWindow.swift
+//  VirtualUI
+//
+//  Created by Guilherme Rambo on 09/03/23.
+//
+
+import Cocoa
+
+class VBRestorableWindow: NSWindow {
+
+    override func close() {
+        vbSaveFrame()
+
+        super.close()
+    }
+
+    private var savedFrameKey: String? {
+        guard let identifier, let screen else { return nil }
+        guard let screenNumber = screen.deviceDescription[.init("NSScreenNumber")] as? Int else { return nil }
+
+        return "window-\(identifier.rawValue)-\(screenNumber)"
+    }
+
+    private var savedFrame: NSRect? {
+        guard let savedFrameKey else { return nil }
+        guard let dict = UserDefaults.standard.dictionary(forKey: savedFrameKey) else { return nil }
+        return NSRect(dictionaryRepresentation: dict as CFDictionary)
+    }
+
+    private var applicationWillTerminateObserver: Any?
+
+    override func makeKey() {
+        super.makeKey()
+
+        if applicationWillTerminateObserver == nil {
+            applicationWillTerminateObserver = NotificationCenter.default.addObserver(forName: NSApplication.willTerminateNotification, object: nil, queue: nil, using: { [weak self] _ in
+                self?.vbSaveFrame()
+            })
+        }
+
+        if let savedFrame {
+            setFrame(savedFrame, display: true)
+        } else {
+            vbSaveFrame()
+        }
+    }
+
+    private func vbSaveFrame() {
+        guard let savedFrameKey else { return }
+        UserDefaults.standard.set(frame.dictionaryRepresentation, forKey: savedFrameKey)
+        UserDefaults.standard.synchronize()
+    }
+
+}

--- a/VirtualUI/Source/Components/VBRestorableWindow.swift
+++ b/VirtualUI/Source/Components/VBRestorableWindow.swift
@@ -30,8 +30,12 @@ class VBRestorableWindow: NSWindow {
 
     private var applicationWillTerminateObserver: Any?
 
+    private var keyRequested = false
+
     override func makeKey() {
         super.makeKey()
+
+        defer { keyRequested = true }
 
         if applicationWillTerminateObserver == nil {
             applicationWillTerminateObserver = NotificationCenter.default.addObserver(forName: NSApplication.willTerminateNotification, object: nil, queue: nil, using: { [weak self] _ in
@@ -39,11 +43,20 @@ class VBRestorableWindow: NSWindow {
             })
         }
 
-        if let savedFrame {
+        if !keyRequested, let savedFrame {
             setFrame(savedFrame, display: true)
         } else {
             vbSaveFrame()
         }
+    }
+
+    override func center() {
+        guard savedFrame == nil else {
+            makeKey()
+            return
+        }
+
+        super.center()
     }
 
     private func vbSaveFrame() {

--- a/VirtualUI/Source/Library/LibraryView.swift
+++ b/VirtualUI/Source/Library/LibraryView.swift
@@ -9,12 +9,11 @@ import SwiftUI
 import VirtualCore
 
 public struct LibraryView: View {
-    @StateObject private var library: VMLibraryController
+    @EnvironmentObject private var library: VMLibraryController
+    @EnvironmentObject private var sessionManager: VirtualMachineSessionUIManager
 
-    public init() {
-        self._library = .init(wrappedValue: .shared)
-    }
-    
+    public init() { }
+
     public var body: some View {
         libraryContents
             .frame(minWidth: 600, maxWidth: .infinity, minHeight: 600, maxHeight: .infinity)
@@ -110,8 +109,9 @@ public struct LibraryView: View {
     
     private func launch(_ vm: VBVirtualMachine) {
         openWindow(id: vm.id) {
-            VirtualMachineSessionView(controller: VMController(with: vm))
+            VirtualMachineSessionView(controller: VMController(with: vm), ui: VirtualMachineSessionUI(with: vm))
                 .environmentObject(library)
+                .environmentObject(sessionManager)
         }
     }
 

--- a/VirtualUI/Source/Session/VirtualMachineSessionUI.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionUI.swift
@@ -1,0 +1,97 @@
+//
+//  VirtualMachineSessionUI.swift
+//  VirtualUI
+//
+//  Created by Guilherme Rambo on 09/03/23.
+//
+
+import SwiftUI
+import VirtualCore
+import Combine
+import AVFoundation
+
+public final class VirtualMachineSessionUIManager: ObservableObject {
+    public let focusedSessionChanged = PassthroughSubject<VirtualMachineSessionUI?, Never>()
+
+    public static let shared = VirtualMachineSessionUIManager()
+
+    private init() { }
+}
+
+public final class VirtualMachineSessionUI: ObservableObject {
+
+    public enum WindowSize: Int {
+        case pointAccurate
+        case pixelAccurate
+        case fitScreen
+    }
+
+    @Published public var lockProportions = false
+
+    let setWindowAspectRatio = PassthroughSubject<CGSize?, Never>()
+
+    let resizeWindow = PassthroughSubject<WindowSize, Never>()
+
+    public let virtualMachine: VBVirtualMachine
+
+    private lazy var cancellables = Set<AnyCancellable>()
+
+    public init(with virtualMachine: VBVirtualMachine) {
+        self.virtualMachine = virtualMachine
+
+        $lockProportions.dropFirst().removeDuplicates().sink { [weak self] newValue in
+            guard let self = self else { return }
+
+            guard let display = self.virtualMachine.configuration.hardware.displayDevices.first else {
+                assertionFailure("VM doesn't have a display")
+                return
+            }
+
+            let ratio = newValue ? CGSize(width: display.width, height: display.height) : nil
+
+            self.setWindowAspectRatio.send(ratio)
+        }
+        .store(in: &cancellables)
+    }
+
+}
+
+public struct VirtualMachineWindowCommands: View {
+    @EnvironmentObject private var manager: VirtualMachineSessionUIManager
+
+    @State private var focusedSession: VirtualMachineSessionUI?
+
+    @State private var lockProportions = false
+
+    public init() { }
+
+    public var body: some View {
+        Group {
+            Toggle("Lock Proportions", isOn: $lockProportions)
+
+            Button("Point Accurate") {
+                focusedSession?.resizeWindow.send(.pointAccurate)
+            }
+            .keyboardShortcut("1", modifiers: .command)
+
+            Button("Pixel Accurate") {
+                focusedSession?.resizeWindow.send(.pixelAccurate)
+            }
+            .keyboardShortcut("2", modifiers: .command)
+
+            Button("Fit Screen") {
+                focusedSession?.resizeWindow.send(.fitScreen)
+            }
+            .keyboardShortcut("3", modifiers: .command)
+        }
+        .disabled(focusedSession == nil)
+        .onReceive(manager.focusedSessionChanged) { focusedSession = $0 }
+        .onChange(of: lockProportions) { [lockProportions] newValue in
+            guard newValue != lockProportions else { return }
+            focusedSession?.lockProportions = newValue
+        }
+
+        Divider()
+    }
+
+}

--- a/VirtualUI/Source/Session/VirtualMachineSessionView.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionView.swift
@@ -168,10 +168,10 @@ struct VMScreenshotBackgroundView: View {
                     .aspectRatio(contentMode: .fit)
             }
             
-//            MaterialView()
-//                .materialType(.popover)
-//                .materialBlendingMode(.withinWindow)
-//                .materialState(.followsWindowActiveState)
+            MaterialView()
+                .materialType(.popover)
+                .materialBlendingMode(.withinWindow)
+                .materialState(.followsWindowActiveState)
         }
         .onAppearOnce { updateImage() }
         .onReceive(vm.didInvalidateThumbnail) { updateImage() }


### PR DESCRIPTION
This adds new options to the Window menu to resize the active VM window based on the resolution of the virtual display.

The "Lock Proportions" toggle locks the window's aspect ratio to match the VM's display.

<img width="355" alt="CleanShot 2023-03-09 at 15 25 52@2x" src="https://user-images.githubusercontent.com/67184/224120740-b3d48aa3-1aed-49ca-8cb8-c19710d07c9d.png">
