### PR TITLE
Automatically sizing VM window

### DIFF
--- a/VirtualUI/Source/Components/HostingWindowController/VBRestorableWindow.swift
+++ b/VirtualUI/Source/Components/HostingWindowController/VBRestorableWindow.swift
@@ -22,6 +22,8 @@ class VBRestorableWindow: NSWindow {
         return "window-\(identifier.rawValue)-\(screenNumber)"
     }
 
+    var hasSavedFrame: Bool { savedFrame != nil }
+
     private var savedFrame: NSRect? {
         guard let savedFrameKey else { return nil }
         guard let dict = UserDefaults.standard.dictionary(forKey: savedFrameKey) else { return nil }
@@ -45,8 +47,6 @@ class VBRestorableWindow: NSWindow {
 
         if !keyRequested, let savedFrame {
             setFrame(savedFrame, display: true)
-        } else {
-            vbSaveFrame()
         }
     }
 

--- a/VirtualUI/Source/Session/VirtualMachineSessionView.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionView.swift
@@ -39,6 +39,11 @@ public struct VirtualMachineSessionView: View {
             .onWindowKeyChange { isKey in
                 sessionManager.focusedSessionChanged.send(isKey ? ui : nil)
             }
+            .onAppearOnce {
+                guard vbWindow?.hasSavedFrame == false else { return }
+                guard let display = controller.virtualMachineModel.configuration.hardware.displayDevices.first else { return }
+                vbWindow?.resize(to: .fitScreen, for: display)
+            }
             .onReceive(ui.resizeWindow) { size in
                 guard let display = controller.virtualMachineModel.configuration.hardware.displayDevices.first else {
                     assertionFailure("VM doesn't have a display")


### PR DESCRIPTION
This makes the window fit to screen automatically when there's no saved frame for the window/display combo, fixing an issue where it would show up as a tiny window in the bottom-left corner.