### PR TITLE
Lowered minimum boot disk size to 2GB

### DIFF
--- a/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
+++ b/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
@@ -61,8 +61,8 @@ public struct VBManagedDiskImage: Identifiable, Hashable, Codable {
         self.format = format
     }
     
-    public static let defaultBootDiskImageSize: UInt64 = 128 * .storageGigabyte
-    public static let minimumBootDiskImageSize: UInt64 = 64 * .storageGigabyte
+    public static let defaultBootDiskImageSize: UInt64 = 64 * .storageGigabyte
+    public static let minimumBootDiskImageSize: UInt64 = 2 * .storageGigabyte
     public static let maximumBootDiskImageSize: UInt64 = 512 * .storageGigabyte
 
     public static let minimumExtraDiskImageSize: UInt64 = 1 * .storageGigabyte


### PR DESCRIPTION
This implements #158

- Minimum boot disk size is now 2GB, regardless of OS
- Default boot disk size lowered from 128GB to 64GB

Future improvements:

- Attempt to suggest the minimum required boot disk size when a macOS restore image is available
- Warn when storage size might be too low for the given OS
- Save last used boot disk image size and use that as the default for new VMs