### PR TITLE
VM window aspect ratio

### DIFF
--- a/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
+++ b/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
@@ -453,7 +453,7 @@ public extension VBDisplayDevice {
     static var matchHost: VBDisplayDevice {
         guard let screen = NSScreen.main else { return .fallback }
 
-        guard let resolution = screen.deviceDescription[.resolution] as? NSSize else { return .fallback }
+        let resolution = screen.dpi
         guard let size = screen.deviceDescription[.size] as? NSSize else { return .fallback }
 
         let pointHeight = size.height - screen.safeAreaInsets.top
@@ -606,7 +606,7 @@ public extension VBDisplayDevice {
         minimumDisplayDimension...maximumDisplayHeight
     }()
 
-    static let minimumDisplayPPI = 80
+    static let minimumDisplayPPI = 72
 
     static let maximumDisplayPPI = 218
 
@@ -654,4 +654,10 @@ public extension ProcessInfo {
     }
     
     var vb_mainDisplayHasNotch: Bool { NSScreen.main?.auxiliaryTopLeftArea != nil }
+}
+
+public extension NSScreen {
+    var dpi: CGSize {
+        (deviceDescription[NSDeviceDescriptionKey.resolution] as? CGSize) ?? CGSize(width: 72.0, height: 72.0)
+    }
 }

--- a/VirtualUI/Source/Components/HostingWindowController/VBRestorableWindow+Resizing.swift
+++ b/VirtualUI/Source/Components/HostingWindowController/VBRestorableWindow+Resizing.swift
@@ -76,9 +76,3 @@ extension VBRestorableWindow {
     }
 
 }
-
-extension NSScreen {
-    var dpi: CGSize {
-        (deviceDescription[NSDeviceDescriptionKey.resolution] as? CGSize) ?? CGSize(width: 72.0, height: 72.0)
-    }
-}

--- a/VirtualUI/Source/Components/HostingWindowController/VBRestorableWindow+Resizing.swift
+++ b/VirtualUI/Source/Components/HostingWindowController/VBRestorableWindow+Resizing.swift
@@ -68,9 +68,9 @@ extension VBRestorableWindow {
             return
         }
 
-        aspectRatio = ratio
+        contentAspectRatio = ratio
 
-        let newFrame = frameRect(forContentRect: AVMakeRect(aspectRatio: ratio, insideRect: frame))
+        let newFrame = frameRect(forContentRect: AVMakeRect(aspectRatio: ratio, insideRect: contentRect(forFrameRect: frame)))
 
         setFrame(newFrame, display: true)
     }

--- a/VirtualUI/Source/Session/VirtualMachineSessionUI.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionUI.swift
@@ -61,7 +61,8 @@ public struct VirtualMachineWindowCommands: View {
 
     @State private var focusedSession: VirtualMachineSessionUI?
 
-    @State private var lockProportions = false
+    @AppStorage("vm.window.proportions.locked")
+    private var lockProportions = false
 
     public init() { }
 
@@ -85,7 +86,10 @@ public struct VirtualMachineWindowCommands: View {
             .keyboardShortcut("3", modifiers: .command)
         }
         .disabled(focusedSession == nil)
-        .onReceive(manager.focusedSessionChanged) { focusedSession = $0 }
+        .onReceive(manager.focusedSessionChanged) {
+            focusedSession = $0
+            focusedSession?.lockProportions = lockProportions
+        }
         .onChange(of: lockProportions) { [lockProportions] newValue in
             guard newValue != lockProportions else { return }
             focusedSession?.lockProportions = newValue


### PR DESCRIPTION
This PR fixes minor issues with the "Lock Proportions" setting in the Window menu.

I moved the `NSScreen.dpi` extension so that the same default resolution can be used as a fallback everywhere, and I reduced the minimum resolution to 72 DPI for consistency (yes, such screens still exist)