### PR TITLE
Change minimum display height to 600

### DIFF
--- a/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
+++ b/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
@@ -596,18 +596,20 @@ public extension VBMacDevice {
 
 public extension VBDisplayDevice {
 
-    static let minimumDisplayDimension = 800
+    static let minimumDisplayWidth = 800
+    
+    static let minimumDisplayHeight = 600
 
     static var maximumDisplayWidth = 6016
 
     static var maximumDisplayHeight = 3384
 
     static let displayWidthRange: ClosedRange<Int> = {
-        minimumDisplayDimension...maximumDisplayWidth
+        minimumDisplayWidth...maximumDisplayWidth
     }()
 
     static let displayHeightRange: ClosedRange<Int> = {
-        minimumDisplayDimension...maximumDisplayHeight
+        minimumDisplayHeight...maximumDisplayHeight
     }()
 
     static let minimumDisplayPPI = 72


### PR DESCRIPTION
The current limit is 800 pixels for both width and height. This PR lowers the height limit to 600 pixels.

This is to allow configuring common resolutions like 800x600 and 1024x768.