### PR TITLE
Add option in display settings to toggle automatic display configuration

### DIFF
--- a/VirtualCore/Source/Models/Configuration/ConfigurationModels+Validation.swift
+++ b/VirtualCore/Source/Models/Configuration/ConfigurationModels+Validation.swift
@@ -55,6 +55,9 @@ public extension VBMacConfiguration {
         if hardware.networkDevices.contains(where: { $0.kind == .bridge }), !VBNetworkDevice.appSupportsBridgedNetworking {
             errors.append(VBNetworkDevice.bridgeUnsupportedMessage)
         }
+        if !VBDisplayDevice.automaticallyReconfiguresDisplaySupportedByHost {
+            errors.append(VBDisplayDevice.automaticallyReconfiguresDisplayUnsupportedMessage)
+        }
         
         return SupportState(errors: errors, warnings: warnings)
     }
@@ -136,6 +139,20 @@ public extension VBNetworkDevice {
     }
     
     static let bridgeUnsupportedMessage = "Bridged network devices are not available in this build of the app."
+}
+
+public extension VBDisplayDevice {
+    static let automaticallyReconfiguresDisplayWarningMessage = "Automatic display configuration is only recognized by VMs running macOS 14 and later."
+    
+    static let automaticallyReconfiguresDisplayUnsupportedMessage = "Automatic display configuration requires both host and VM to be on macOS 14 or later."
+    
+    static var automaticallyReconfiguresDisplaySupportedByHost: Bool {
+        if #available(macOS 14.0, *) {
+            return true
+        } else {
+            return false
+        }
+    }
 }
 
 public extension VBPointingDevice.Kind {

--- a/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
+++ b/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
@@ -186,12 +186,13 @@ public struct VBStorageDevice: Identifiable, Hashable, Codable {
 /// Configures a display device.
 /// **Read the note at the top of this file before modifying this**
 public struct VBDisplayDevice: Identifiable, Hashable, Codable {
-    public init(id: UUID = UUID(), name: String = "Default", width: Int = 1920, height: Int = 1080, pixelsPerInch: Int = 144) {
+    public init(id: UUID = UUID(), name: String = "Default", width: Int = 1920, height: Int = 1080, pixelsPerInch: Int = 144, automaticallyReconfiguresDisplay: Bool = false) {
         self.id = id
         self.name = name
         self.width = width
         self.height = height
         self.pixelsPerInch = pixelsPerInch
+        self.automaticallyReconfiguresDisplay = automaticallyReconfiguresDisplay
     }
     
     public var id = UUID()
@@ -199,6 +200,7 @@ public struct VBDisplayDevice: Identifiable, Hashable, Codable {
     public var width = 1920
     public var height = 1080
     public var pixelsPerInch = 144
+    @DecodableDefault.False public var automaticallyReconfiguresDisplay = false
 }
 
 /// Configures a network device.

--- a/VirtualUI/Source/Session/VirtualMachineSessionView.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionView.swift
@@ -83,7 +83,7 @@ public struct VirtualMachineSessionView: View {
         SwiftUIVMView(
             controllerState: .constant(.running(vm)),
             captureSystemKeys: controller.virtualMachineModel.configuration.captureSystemKeys,
-            automaticallyReconfiguresDisplay: .constant(true),
+            automaticallyReconfiguresDisplay: .constant(controller.virtualMachineModel.configuration.hardware.displayDevices.count > 0 ? controller.virtualMachineModel.configuration.hardware.displayDevices[0].automaticallyReconfiguresDisplay : false),
             screenshotSubject: screenshotTaken
         )
     }

--- a/VirtualUI/Source/VM Configuration/Sections/DisplayConfigurationView.swift
+++ b/VirtualUI/Source/VM Configuration/Sections/DisplayConfigurationView.swift
@@ -46,6 +46,18 @@ struct DisplayConfigurationView: View {
                 spacing: VMConfigurationView.labelSpacing
             )
         }
+        
+        Toggle("Automatically Configure Display", isOn: $device.automaticallyReconfiguresDisplay)
+        
+        if VBDisplayDevice.automaticallyReconfiguresDisplaySupportedByHost {
+            if (device.automaticallyReconfiguresDisplay) {
+                Text(VBDisplayDevice.automaticallyReconfiguresDisplayWarningMessage)
+                    .foregroundColor(.yellow)
+            }
+        } else {
+            Text(VBDisplayDevice.automaticallyReconfiguresDisplayUnsupportedMessage)
+                .foregroundColor(.red)
+        }
     }
     
     @ViewBuilder


### PR DESCRIPTION
Add an option on the **Display** section of the VM settings page to toggle automatic display configuration. Guards and warning messages are added since this feature requires both host and guest to be of macOS 14 or later.

Tested that VirtualBuddy can run properly with the old VM's `.plist` file that doesn't have the `automaticallyReconfiguresDisplay` key, with the default value set to `false`.