### PR TITLE
Add remaining missing IPSW files

### DIFF
--- a/data/ipsws_v1.json
+++ b/data/ipsws_v1.json
@@ -187,17 +187,17 @@
     },
     {
       "group": "ventura",
-      "name": "macOS 13.4.1 (M2 Host)",
-      "build": "22F2083",
-      "url": "https://updates.cdn-apple.com/2023SpringFCS/fullrestores/042-01864/A8378F91-BA71-40DF-8F0D-606A16F1836B/UniversalMac_13.4.1_22F2083_Restore.ipsw",
+      "name": "macOS 13.4.1",
+      "build": "22F82",
+      "url": "https://updates.cdn-apple.com/2023SpringFCS/fullrestores/042-01877/2F49A9FE-7033-41D0-9D0C-64EFCE6B4C22/UniversalMac_13.4.1_22F82_Restore.ipsw",
       "channel": "regular",
       "needsCookie": false
     },
     {
       "group": "ventura",
-      "name": "macOS 13.4.1 (M1 Host)",
-      "build": "22F82",
-      "url": "https://updates.cdn-apple.com/2023SpringFCS/fullrestores/042-01877/2F49A9FE-7033-41D0-9D0C-64EFCE6B4C22/UniversalMac_13.4.1_22F82_Restore.ipsw",
+      "name": "macOS 13.4.1 (WWDC23 M2 Macs)",
+      "build": "22F2083",
+      "url": "https://updates.cdn-apple.com/2023SpringFCS/fullrestores/042-01864/A8378F91-BA71-40DF-8F0D-606A16F1836B/UniversalMac_13.4.1_22F2083_Restore.ipsw",
       "channel": "regular",
       "needsCookie": false
     },
@@ -271,6 +271,14 @@
       "build": "22E252",
       "url": "https://updates.cdn-apple.com/2023WinterSeed/fullrestores/002-75537/8250FA0E-0962-46D6-8A90-57A390B9FFD7/UniversalMac_13.3_22E252_Restore.ipsw",
       "channel": "regular",
+      "needsCookie": false
+    },
+    {
+      "group": "ventura",
+      "name": "macOS 13.3 Developer Beta 4",
+      "build": "22E5246b",
+      "url": "https://updates.cdn-apple.com/2023WinterSeed/fullrestores/032-63669/7C0F9BA8-35C0-457F-AF56-6943D58A2CDB/UniversalMac_13.3_22E5246b_Restore.ipsw",
+      "channel": "devbeta",
       "needsCookie": false
     },
     {
@@ -523,10 +531,90 @@
     },
     {
       "group": "monterey",
+      "name": "macOS 12.5 RC",
+      "build": "21G69",
+      "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-40368/5DD0A524-140A-46AF-91ED-5F28EA9DEC01/UniversalMac_12.5_21G69_Restore.ipsw",
+      "channel": "devbeta",
+      "needsCookie": false
+    },
+    {
+      "group": "monterey",
+      "name": "macOS 12.5 Developer Beta 5",
+      "build": "21G5063a",
+      "url": "https://updates.cdn-apple.com/2022FallSeed/fullrestores/012-36748/52342C55-6598-4A86-AAB8-8901145792C8/UniversalMac_12.5_21G5063a_Restore.ipsw",
+      "channel": "devbeta",
+      "needsCookie": false
+    },
+    {
+      "group": "monterey",
+      "name": "macOS 12.5 Developer Beta 4",
+      "build": "21G5056b",
+      "url": "https://updates.cdn-apple.com/2022FallSeed/fullrestores/012-26441/AE0AC638-2773-49D3-BF84-950B10BF39E9/UniversalMac_12.5_21G5056b_Restore.ipsw",
+      "channel": "devbeta",
+      "needsCookie": false
+    },
+    {
+      "group": "monterey",
+      "name": "macOS 12.5 Developer Beta 3",
+      "build": "21G5046c",
+      "url": "https://updates.cdn-apple.com/2022FallSeed/fullrestores/012-18271/FFF202B2-E4B6-4A3E-9681-42A0F3F81B11/UniversalMac_12.5_21G5046c_Restore.ipsw",
+      "channel": "devbeta",
+      "needsCookie": false
+    },
+    {
+      "group": "monterey",
+      "name": "macOS 12.5 Developer Beta 2",
+      "build": "21G5037d",
+      "url": "https://updates.cdn-apple.com/2022FallSeed/fullrestores/012-10648/1CC63FC5-5A22-4A5A-9A7B-C19C8C4A6731/UniversalMac_12.5_21G5037d_Restore.ipsw",
+      "channel": "devbeta",
+      "needsCookie": false
+    },
+    {
+      "group": "monterey",
+      "name": "macOS 12.5 Developer Beta 1",
+      "build": "21G5027d",
+      "url": "https://updates.cdn-apple.com/2022FallSeed/fullrestores/002-93712/5F234425-6096-43FC-B518-1E9D7B4D0254/UniversalMac_12.5_21G5027d_Restore.ipsw",
+      "channel": "devbeta",
+      "needsCookie": false
+    },
+    {
+      "group": "monterey",
       "name": "macOS 12.4",
       "build": "21F79",
       "url": "https://updates.cdn-apple.com/2022SpringFCS/fullrestores/012-06874/9CECE956-D945-45E2-93E9-4FFDC81BB49A/UniversalMac_12.4_21F79_Restore.ipsw",
       "channel": "regular",
+      "needsCookie": false
+    },
+    {
+      "group": "monterey",
+      "name": "macOS 12.4 Developer Beta 4",
+      "build": "21F5071b",
+      "url": "https://updates.cdn-apple.com/2022SpringSeed/fullrestores/002-95106/0F7A6388-C4B5-4B8E-B8B2-F62C030699D0/UniversalMac_12.4_21F5071b_Restore.ipsw",
+      "channel": "devbeta",
+      "needsCookie": false
+    },
+    {
+      "group": "monterey",
+      "name": "macOS 12.4 Developer Beta 3",
+      "build": "21F5063e",
+      "url": "https://updates.cdn-apple.com/2022SpringSeed/fullrestores/002-90009/DA6BD192-1698-48B3-AB6D-9D3A045ED1B1/UniversalMac_12.4_21F5063e_Restore.ipsw",
+      "channel": "devbeta",
+      "needsCookie": false
+    },
+    {
+      "group": "monterey",
+      "name": "macOS 12.4 Developer Beta 2",
+      "build": "21F5058e",
+      "url": "https://updates.cdn-apple.com/2022SpringSeed/fullrestores/002-87587/BC2EBE80-F0F4-4B56-BCDC-340E0AD8E985/UniversalMac_12.4_21F5058e_Restore.ipsw",
+      "channel": "devbeta",
+      "needsCookie": false
+    },
+    {
+      "group": "monterey",
+      "name": "macOS 12.4 Developer Beta 1",
+      "build": "21F5048e",
+      "url": "https://updates.cdn-apple.com/2022SpringSeed/fullrestores/002-85721/A21FF659-8493-4A16-A989-2C3141F48D8C/UniversalMac_12.4_21F5048e_Restore.ipsw",
+      "channel": "devbeta",
       "needsCookie": false
     },
     {


### PR DESCRIPTION
This PR adds all remaining IPSW files, including betas and special releases, not currently listed going back to macOS 12.3.1. I tried to make the comments on the special releases clear, but feel free to push changes.