### PR TITLE
Fix automatically configure display error

### DIFF
--- a/VirtualCore/Source/Models/Configuration/ConfigurationModels+Validation.swift
+++ b/VirtualCore/Source/Models/Configuration/ConfigurationModels+Validation.swift
@@ -52,9 +52,6 @@ public extension VBMacConfiguration {
         if hardware.networkDevices.contains(where: { $0.kind == .bridge }), !VBNetworkDevice.appSupportsBridgedNetworking {
             errors.append(VBNetworkDevice.bridgeUnsupportedMessage)
         }
-        if !VBDisplayDevice.automaticallyReconfiguresDisplaySupportedByHost {
-            errors.append(VBDisplayDevice.automaticallyReconfiguresDisplayUnsupportedMessage)
-        }
         
         return SupportState(errors: errors, warnings: warnings)
     }

--- a/VirtualUI/Source/VM Configuration/Sections/DisplayConfigurationView.swift
+++ b/VirtualUI/Source/VM Configuration/Sections/DisplayConfigurationView.swift
@@ -47,7 +47,9 @@ struct DisplayConfigurationView: View {
             )
         }
         
-        Toggle("Automatically Configure Display", isOn: $device.automaticallyReconfiguresDisplay)
+        if #available(macOS 14.0, *) {
+            Toggle("Automatically Configure Display", isOn: $device.automaticallyReconfiguresDisplay)
+        }
         
         if VBDisplayDevice.automaticallyReconfiguresDisplaySupportedByHost {
             if (device.automaticallyReconfiguresDisplay) {


### PR DESCRIPTION
Make error non-fatal and hide checkbox when running before macOS Sonoma.

This error was popping up even with the checkbox disabled on previous OSes 😬