### PR TITLE
Enable copy-and-paste support between the host and a Linux guest

### DIFF
--- a/VirtualCore/Source/Virtualization/Helpers/LinuxVirtualMachineConfigurationHelper.swift
+++ b/VirtualCore/Source/Virtualization/Helpers/LinuxVirtualMachineConfigurationHelper.swift
@@ -36,6 +36,17 @@ struct LinuxVirtualMachineConfigurationHelper: VirtualMachineConfigurationHelper
 
         return [graphicsConfiguration]
     }
+
+    func createSpiceAgentConsoleDeviceConfiguration() -> VZVirtioConsoleDeviceConfiguration {
+        let consoleDevice = VZVirtioConsoleDeviceConfiguration()
+
+        let spiceAgentPort = VZVirtioConsolePortConfiguration()
+        spiceAgentPort.name = VZSpiceAgentPortAttachment.spiceAgentPortName
+        spiceAgentPort.attachment = VZSpiceAgentPortAttachment()
+        consoleDevice.ports[0] = spiceAgentPort
+
+        return consoleDevice
+    }
 }
 
 // MARK: - Configuration Models -> Virtualization

--- a/VirtualCore/Source/Virtualization/VMInstance.swift
+++ b/VirtualCore/Source/Virtualization/VMInstance.swift
@@ -124,6 +124,9 @@ public final class VMInstance: NSObject, ObservableObject {
         c.entropyDevices = helper.createEntropyDevices()
         c.audioDevices = model.configuration.vzAudioDevices
         c.directorySharingDevices = try model.configuration.vzSharedFoldersFileSystemDevices
+        if model.configuration.systemType == .linux, #available(macOS 13.0, *) {
+            c.consoleDevices = [(helper as! LinuxVirtualMachineConfigurationHelper).createSpiceAgentConsoleDeviceConfiguration()]
+        }
 
         let bootDevice = try await helper.createBootBlockDevice()
         let additionalBlockDevices = try await helper.createAdditionalBlockDevices()


### PR DESCRIPTION
Many thanks for this wonderful piece of software. I added copy-and-paste support for Linux (tested with Ubuntu Desktop), according to the documentation from Apple. To use the copy-and-paste capability in Linux, the user needs to install the spice-vdagent package, which is available through most Linux package managers.