### PR TITLE
Moved spice agent requirement into VirtualMachineConfigurationHelper protocol

### DIFF
--- a/VirtualCore/Source/Virtualization/Helpers/LinuxVirtualMachineConfigurationHelper.swift
+++ b/VirtualCore/Source/Virtualization/Helpers/LinuxVirtualMachineConfigurationHelper.swift
@@ -37,7 +37,8 @@ struct LinuxVirtualMachineConfigurationHelper: VirtualMachineConfigurationHelper
         return [graphicsConfiguration]
     }
 
-    func createSpiceAgentConsoleDeviceConfiguration() -> VZVirtioConsoleDeviceConfiguration {
+    @available(macOS 13.0, *)
+    func createSpiceAgentConsoleDeviceConfiguration() -> VZVirtioConsoleDeviceConfiguration? {
         let consoleDevice = VZVirtioConsoleDeviceConfiguration()
 
         let spiceAgentPort = VZVirtioConsolePortConfiguration()

--- a/VirtualCore/Source/Virtualization/Helpers/VirtualMachineConfigurationHelper.swift
+++ b/VirtualCore/Source/Virtualization/Helpers/VirtualMachineConfigurationHelper.swift
@@ -17,6 +17,8 @@ protocol VirtualMachineConfigurationHelper {
     func createKeyboardConfiguration() -> VZKeyboardConfiguration
     func createGraphicsDevices() -> [VZGraphicsDeviceConfiguration]
     func createEntropyDevices() -> [VZVirtioEntropyDeviceConfiguration]
+    @available(macOS 13.0, *)
+    func createSpiceAgentConsoleDeviceConfiguration() -> VZVirtioConsoleDeviceConfiguration?
 }
 
 extension VirtualMachineConfigurationHelper {
@@ -51,6 +53,9 @@ extension VirtualMachineConfigurationHelper {
     }
 
     func createEntropyDevices() -> [VZVirtioEntropyDeviceConfiguration] { [] }
+
+    @available(macOS 13.0, *)
+    func createSpiceAgentConsoleDeviceConfiguration() -> VZVirtioConsoleDeviceConfiguration? { nil }
 
 }
 

--- a/VirtualCore/Source/Virtualization/VMInstance.swift
+++ b/VirtualCore/Source/Virtualization/VMInstance.swift
@@ -124,8 +124,8 @@ public final class VMInstance: NSObject, ObservableObject {
         c.entropyDevices = helper.createEntropyDevices()
         c.audioDevices = model.configuration.vzAudioDevices
         c.directorySharingDevices = try model.configuration.vzSharedFoldersFileSystemDevices
-        if model.configuration.systemType == .linux, #available(macOS 13.0, *) {
-            c.consoleDevices = [(helper as! LinuxVirtualMachineConfigurationHelper).createSpiceAgentConsoleDeviceConfiguration()]
+        if #available(macOS 13.0, *), let spiceAgent = helper.createSpiceAgentConsoleDeviceConfiguration() {
+            c.consoleDevices = [spiceAgent]
         }
 
         let bootDevice = try await helper.createBootBlockDevice()


### PR DESCRIPTION
This is a minor adjustment to the work done in #242 

Made `createSpiceAgentConsoleDeviceConfiguration` a requirement of the `VirtualMachineConfigurationHelper` protocol, with default implementation returning `nil` and Linux implementation returning a spice agent instance.