### PR TITLE
Several improvements to host<>guest communication

### DIFF
--- a/VirtualBuddy.xcodeproj/project.pbxproj
+++ b/VirtualBuddy.xcodeproj/project.pbxproj
@@ -60,6 +60,9 @@
 		F422587E2885E2ED009420AE /* HardwareConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F422587D2885E2ED009420AE /* HardwareConfigurationView.swift */; };
 		F42258802885E71D009420AE /* PropertyControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = F422587F2885E71D009420AE /* PropertyControl.swift */; };
 		F428622D2AE8726D0052F029 /* VirtualMachineControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = F428622C2AE8726D0052F029 /* VirtualMachineControls.swift */; };
+		F428622E2AE87D7E0052F029 /* DeepLinkSecurity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F43B01152AD858FE00164CD1 /* DeepLinkSecurity.framework */; };
+		F428622F2AE87D7E0052F029 /* DeepLinkSecurity.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F43B01152AD858FE00164CD1 /* DeepLinkSecurity.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F42862372AE947C90052F029 /* WHPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42862362AE947C90052F029 /* WHPayload.swift */; };
 		F42C014A2888C2F800EB15CD /* InstallationConsole.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42C01492888C2F800EB15CD /* InstallationConsole.swift */; };
 		F42C014C2888C34B00EB15CD /* LogConsole.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42C014B2888C34B00EB15CD /* LogConsole.swift */; };
 		F42C014E2888CBCB00EB15CD /* InstallProgressStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42C014D2888CBCB00EB15CD /* InstallProgressStepView.swift */; };
@@ -226,6 +229,13 @@
 			remoteGlobalIDString = F41369AA29918576002CE8D3;
 			remoteInfo = VirtualBuddyGuestHelper;
 		};
+		F42862302AE87D7E0052F029 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F4BE9C4627FF052100B648F8 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F43B01142AD858FE00164CD1;
+			remoteInfo = DeepLinkSecurity;
+		};
 		F4510A792AE2B3AB00E24DD9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F4BE9C4627FF052100B648F8 /* Project object */;
@@ -322,6 +332,7 @@
 			files = (
 				F4C18A5328491B9D00335EC7 /* VirtualWormhole.framework in Embed Frameworks */,
 				F413699F299179F8002CE8D3 /* VirtualUI.framework in Embed Frameworks */,
+				F428622F2AE87D7E0052F029 /* DeepLinkSecurity.framework in Embed Frameworks */,
 				F413699B299179F8002CE8D3 /* VirtualCore.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -382,6 +393,7 @@
 		F422587D2885E2ED009420AE /* HardwareConfigurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardwareConfigurationView.swift; sourceTree = "<group>"; };
 		F422587F2885E71D009420AE /* PropertyControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyControl.swift; sourceTree = "<group>"; };
 		F428622C2AE8726D0052F029 /* VirtualMachineControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualMachineControls.swift; sourceTree = "<group>"; };
+		F42862362AE947C90052F029 /* WHPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WHPayload.swift; sourceTree = "<group>"; };
 		F42C01492888C2F800EB15CD /* InstallationConsole.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationConsole.swift; sourceTree = "<group>"; };
 		F42C014B2888C34B00EB15CD /* LogConsole.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogConsole.swift; sourceTree = "<group>"; };
 		F42C014D2888CBCB00EB15CD /* InstallProgressStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallProgressStepView.swift; sourceTree = "<group>"; };
@@ -586,6 +598,7 @@
 			files = (
 				F4C18A5228491B9D00335EC7 /* VirtualWormhole.framework in Frameworks */,
 				F413699E299179F8002CE8D3 /* VirtualUI.framework in Frameworks */,
+				F428622E2AE87D7E0052F029 /* DeepLinkSecurity.framework in Frameworks */,
 				F413699A299179F8002CE8D3 /* VirtualCore.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1329,6 +1342,7 @@
 			children = (
 				F4D3059629B8D9D30006E748 /* WormholePacket.swift */,
 				F4D305B129B907A10006E748 /* WHPing.swift */,
+				F42862362AE947C90052F029 /* WHPayload.swift */,
 			);
 			path = WireProtocol;
 			sourceTree = "<group>";
@@ -1574,6 +1588,7 @@
 				F4C18A5528491B9D00335EC7 /* PBXTargetDependency */,
 				F413699D299179F8002CE8D3 /* PBXTargetDependency */,
 				F41369A1299179F8002CE8D3 /* PBXTargetDependency */,
+				F42862312AE87D7E0052F029 /* PBXTargetDependency */,
 			);
 			name = VirtualBuddyGuest;
 			productName = VirtualBuddyGuest;
@@ -1938,6 +1953,7 @@
 				F4C189FA2848F6F700335EC7 /* VirtualWormholeConstants.swift in Sources */,
 				F4BE584229BA7BDB00C5525C /* WHDefaultsImportService.swift in Sources */,
 				F4D305B029B900860006E748 /* SystemNotification.swift in Sources */,
+				F42862372AE947C90052F029 /* WHPayload.swift in Sources */,
 				F4BE581329BA6E0D00C5525C /* DefaultsDomainDescriptor.swift in Sources */,
 				F4BE581129BA6DFC00C5525C /* DefaultsImportController.swift in Sources */,
 				F4D305B229B907A10006E748 /* WHPing.swift in Sources */,
@@ -1990,6 +2006,11 @@
 			isa = PBXTargetDependency;
 			target = F41369AA29918576002CE8D3 /* VirtualBuddyGuestHelper */;
 			targetProxy = F41369BC29918617002CE8D3 /* PBXContainerItemProxy */;
+		};
+		F42862312AE87D7E0052F029 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F43B01142AD858FE00164CD1 /* DeepLinkSecurity */;
+			targetProxy = F42862302AE87D7E0052F029 /* PBXContainerItemProxy */;
 		};
 		F4510A7A2AE2B3AB00E24DD9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/VirtualBuddy.xcodeproj/xcshareddata/xcschemes/VirtualBuddy (Managed).xcscheme
+++ b/VirtualBuddy.xcodeproj/xcshareddata/xcschemes/VirtualBuddy (Managed).xcscheme
@@ -60,6 +60,10 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "-WHDisablePayloadPropagation YES"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-WHVerbosePacketLogging YES"
             isEnabled = "YES">
          </CommandLineArgument>

--- a/VirtualBuddy.xcodeproj/xcshareddata/xcschemes/VirtualBuddy (Managed).xcscheme
+++ b/VirtualBuddy.xcodeproj/xcshareddata/xcschemes/VirtualBuddy (Managed).xcscheme
@@ -61,7 +61,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-WHVerbosePacketLogging YES"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>

--- a/VirtualCore/Source/Virtualization/VMController.swift
+++ b/VirtualCore/Source/Virtualization/VMController.swift
@@ -124,6 +124,8 @@ public final class VMController: ObservableObject {
 
             state = .paused(vm)
         }
+
+        unhideCursor()
     }
     
     public func resume() async throws {
@@ -135,6 +137,8 @@ public final class VMController: ObservableObject {
 
             state = .running(vm)
         }
+
+        unhideCursor()
     }
     
     public func stop() async throws {
@@ -145,6 +149,8 @@ public final class VMController: ObservableObject {
 
             state = .stopped(nil)
         }
+
+        unhideCursor()
     }
     
     public func forceStop() async throws {
@@ -155,6 +161,8 @@ public final class VMController: ObservableObject {
 
             state = .stopped(nil)
         }
+
+        unhideCursor()
     }
 
     private func updatingState(perform block: () async throws -> Void) async throws {
@@ -185,7 +193,14 @@ public final class VMController: ObservableObject {
         }
     }
 
+    public func invalidate() {
+        library.removeController(self)
+    }
+
     deinit {
+        #if DEBUG
+        print("\(id) Bye bye 👋")
+        #endif
         library.removeController(self)
     }
 
@@ -265,4 +280,15 @@ public extension VMController {
 
     var canPause: Bool { state.canPause }
 
+}
+
+public extension VMController {
+    /// Workaround for cursor disappearing due to it being captured
+    /// by Virtualization during state transitions.
+    func unhideCursor() {
+        Task {
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            NSCursor.unhide()
+        }
+    }
 }

--- a/VirtualUI/Source/Session/VirtualMachineSessionView.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionView.swift
@@ -177,11 +177,6 @@ public struct VirtualMachineSessionView: View {
 
             try? await controller.forceStop()
 
-            /// Workaround for cursor disappearing due to it being captured
-            /// between the alert confirmation and the VM stopping.
-            try? await Task.sleep(nanoseconds: 100_000_000)
-            NSCursor.unhide()
-
             return true
         }
     }

--- a/VirtualWormhole/Source/Definitions/VirtualWormholeConstants.swift
+++ b/VirtualWormhole/Source/Definitions/VirtualWormholeConstants.swift
@@ -22,6 +22,10 @@ struct VirtualWormholeConstants {
     static let payloadPropagationEnabled: Bool = {
         !UserDefaults.standard.bool(forKey: "WHDisablePayloadPropagation")
     }()
+
+    static let connectionTimeoutInNanoseconds: UInt64 = 15 * NSEC_PER_SEC
+
+    static let pingIntervalInSeconds: TimeInterval = 5.0
 }
 
 extension Logger {

--- a/VirtualWormhole/Source/Definitions/VirtualWormholeConstants.swift
+++ b/VirtualWormhole/Source/Definitions/VirtualWormholeConstants.swift
@@ -18,6 +18,10 @@ struct VirtualWormholeConstants {
         return false
         #endif
     }()
+
+    static let payloadPropagationEnabled: Bool = {
+        !UserDefaults.standard.bool(forKey: "WHDisablePayloadPropagation")
+    }()
 }
 
 extension Logger {

--- a/VirtualWormhole/Source/Services/Base/WormholeServiceProtocol.swift
+++ b/VirtualWormhole/Source/Services/Base/WormholeServiceProtocol.swift
@@ -12,9 +12,9 @@ public protocol WormholeMultiplexer: AnyObject {
 
     var side: WHConnectionSide { get }
     
-    func send<T: Codable>(_ payload: T, to peerID: WHPeerID?) async
+    func send<T: WHPayload>(_ payload: T, to peerID: WHPeerID?) async
 
-    func stream<T: Codable>(for payloadType: T.Type) -> AsyncThrowingStream<(senderID: WHPeerID, payload: T), Error>
+    func stream<T: WHPayload>(for payloadType: T.Type) -> AsyncThrowingStream<(senderID: WHPeerID, payload: T), Error>
     
 }
 

--- a/VirtualWormhole/Source/Services/DarwinNotifications/WHDarwinNotificationsService.swift
+++ b/VirtualWormhole/Source/Services/DarwinNotifications/WHDarwinNotificationsService.swift
@@ -9,7 +9,9 @@ import Cocoa
 import OSLog
 import Combine
 
-enum DarwinNotificationMessage: Codable {
+enum DarwinNotificationMessage: WHPayload {
+    static let resendOnReconnect = true
+    
     case post(String)
     case subscribe(String)
 }

--- a/VirtualWormhole/Source/Services/DefaultsImport/WHDefaultsImportService.swift
+++ b/VirtualWormhole/Source/Services/DefaultsImport/WHDefaultsImportService.swift
@@ -9,7 +9,7 @@ import Cocoa
 import OSLog
 import Combine
 
-enum DefaultsImportMessage: Codable {
+enum DefaultsImportMessage: WHPayload {
     /// Guest requesting domain export from host.
     case request(domainID: String)
     /// Host responding to guest request with domain ID and associated plist.

--- a/VirtualWormhole/Source/Services/WHSharedClipboardService.swift
+++ b/VirtualWormhole/Source/Services/WHSharedClipboardService.swift
@@ -103,7 +103,15 @@ private extension ClipboardData {
     ]
 
     static var current: [ClipboardData] {
+        guard let availableTypes = NSPasteboard.general.types else { return [] }
+
         return supportedTypes.compactMap { type in
+            /// PNG and TIFF data are often present at the same time.
+            /// Ignore TIFF data and preserve only the PNG data when that's the case,
+            /// since TIFF data is usually much larger and unused.
+            if type == .tiff {
+                guard !availableTypes.contains(.png) else { return nil }
+            }
             guard let data = NSPasteboard.general.data(forType: type) else {
                 return nil
             }

--- a/VirtualWormhole/Source/Services/WHSharedClipboardService.swift
+++ b/VirtualWormhole/Source/Services/WHSharedClipboardService.swift
@@ -13,7 +13,7 @@ struct ClipboardData: Codable, Hashable {
     var value: Data
 }
 
-struct ClipboardMessage: Codable, Hashable {
+struct ClipboardMessage: WHPayload, Hashable {
     var timestamp: Date
     var data: [ClipboardData]
 }

--- a/VirtualWormhole/Source/Services/WHSharedClipboardService.swift
+++ b/VirtualWormhole/Source/Services/WHSharedClipboardService.swift
@@ -16,6 +16,8 @@ struct ClipboardData: Codable, Hashable {
 struct ClipboardMessage: WHPayload, Hashable {
     var timestamp: Date
     var data: [ClipboardData]
+
+    static let propagateBetweenGuests = true
 }
 
 final class WHSharedClipboardService: WormholeService {

--- a/VirtualWormhole/Source/WireProtocol/WHPayload.swift
+++ b/VirtualWormhole/Source/WireProtocol/WHPayload.swift
@@ -11,8 +11,13 @@ import Foundation
 public protocol WHPayload: Codable {
     /// When `true`, the payload will be sent again if connection gets interrupted and re-established.
     static var resendOnReconnect: Bool { get }
+
+    /// When `true`, the host will distribute the payload to all booted guests
+    /// upon receiving the payload from one of the guests.
+    static var propagateBetweenGuests: Bool { get }
 }
 
 public extension WHPayload {
     static var resendOnReconnect: Bool { false }
+    static var propagateBetweenGuests: Bool { false }
 }

--- a/VirtualWormhole/Source/WireProtocol/WHPayload.swift
+++ b/VirtualWormhole/Source/WireProtocol/WHPayload.swift
@@ -1,0 +1,18 @@
+//
+//  WHPayload.swift
+//  VirtualWormhole
+//
+//  Created by Guilherme Rambo on 25/10/23.
+//
+
+import Foundation
+
+/// Protocol adopted by types that can be sent over the guest <> host connection.
+public protocol WHPayload: Codable {
+    /// When `true`, the payload will be sent again if connection gets interrupted and re-established.
+    static var resendOnReconnect: Bool { get }
+}
+
+public extension WHPayload {
+    static var resendOnReconnect: Bool { false }
+}

--- a/VirtualWormhole/Source/WireProtocol/WHPing.swift
+++ b/VirtualWormhole/Source/WireProtocol/WHPing.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 
-struct WHPing: Codable {
+struct WHPing: WHPayload {
     var date = Date.now
 }
 
-struct WHPong: Codable {
+struct WHPong: WHPayload {
     var date = Date.now
 }
 

--- a/VirtualWormhole/Source/WireProtocol/WHPing.swift
+++ b/VirtualWormhole/Source/WireProtocol/WHPing.swift
@@ -19,3 +19,12 @@ extension WormholePacket {
     var isPing: Bool { payloadType == String(describing: WHPing.self) }
     var isPong: Bool { payloadType == String(describing: WHPong.self) }
 }
+
+extension WormholePacket {
+    static var ping: WormholePacket {
+        get throws { try WormholePacket(WHPing()) }
+    }
+    static var pong: WormholePacket {
+        get throws { try WormholePacket(WHPong()) }
+    }
+}

--- a/VirtualWormhole/Source/WireProtocol/WormholePacket.swift
+++ b/VirtualWormhole/Source/WireProtocol/WormholePacket.swift
@@ -36,7 +36,7 @@ extension WormholePacket {
 extension WormholePacket {
 
     init<T: Codable>(_ payload: T) throws {
-        let data = try JSONEncoder().encode(payload)
+        let data = try JSONEncoder.wormhole.encode(payload)
         let typeName = String(describing: type(of: payload))
 
         self.init(payloadType: typeName, payloadLength: UInt64(data.count), payload: data)
@@ -171,4 +171,12 @@ extension WormholePacket {
         }
     }
 
+}
+
+extension JSONDecoder {
+    static let wormhole = JSONDecoder()
+}
+
+extension JSONEncoder {
+    static let wormhole = JSONEncoder()
 }

--- a/VirtualWormhole/Source/WormholeManager.swift
+++ b/VirtualWormhole/Source/WormholeManager.swift
@@ -100,7 +100,7 @@ public final class WormholeManager: NSObject, ObservableObject, WormholeMultiple
         #endif
 
         Timer
-            .publish(every: 3, tolerance: 1.5, on: .main, in: .common)
+            .publish(every: VirtualWormholeConstants.pingIntervalInSeconds, tolerance: VirtualWormholeConstants.pingIntervalInSeconds * 0.5, on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in
                 guard let self = self else { return }
@@ -497,7 +497,7 @@ actor WormholeChannel: ObservableObject {
         timeoutTask?.cancel()
 
         timeoutTask = Task {
-            try? await Task.sleep(nanoseconds: 5 * NSEC_PER_SEC)
+            try? await Task.sleep(nanoseconds: VirtualWormholeConstants.connectionTimeoutInNanoseconds)
 
             guard !Task.isCancelled else { return }
 


### PR DESCRIPTION
- Formalizes `WHPayload` protocol for models that can be transferred between machines, with options to propagate payloads of a given type between guests and re-send payloads when interrupted connections are re-established
- Thanks to the above, shared clipboard contents are now propagated between guests, not just from host to/from individual guest as before
- Addresses an issue that caused the shared clipboard to stop working after stopping and restarting a VM
- Fixes a bunch of memory leaks related to the host<>guest connection

TBD: current transport is too slow for most stuff other than text and small images, will need new transport in order to enable future developments