### PR TITLE
Fixes bug where install would skip configuration step

### DIFF
--- a/VirtualUI/Source/Installer/Components/VirtualMachineNameField.swift
+++ b/VirtualUI/Source/Installer/Components/VirtualMachineNameField.swift
@@ -10,13 +10,12 @@ import VirtualCore
 
 struct VirtualMachineNameField: View {
     @Binding var name: String
-    var onCommit: () -> Void
 
     @FocusState private var isFocused: Bool
 
     var body: some View {
         HStack {
-            TextField("Virtual Mac Name", text: $name, onCommit: onCommit)
+            TextField("Virtual Mac Name", text: $name)
                 .textFieldStyle(.roundedBorder)
                 .controlSize(.large)
                 .focused($isFocused)

--- a/VirtualUI/Source/Installer/VMInstallationWizard.swift
+++ b/VirtualUI/Source/Installer/VMInstallationWizard.swift
@@ -147,7 +147,7 @@ public struct VMInstallationWizard: View {
         VStack {
             InstallationWizardTitle("Name Your Virtual Machine")
 
-            VirtualMachineNameField(name: $viewModel.data.name, onCommit: viewModel.goNext)
+            VirtualMachineNameField(name: $viewModel.data.name)
         }
     }
 


### PR DESCRIPTION
This fixes a really annoying bug that took me a while to figure out: the name field during configuration had an `onCommit` callback that was calling `goNext` on the view model, but there's already a button with the `.defaultAction` shortcut in the wizard, so the result was that if the rename was committed with the return key, the installer would skip past the configuration step and go right into installation.