### PR TITLE
Remember last used directory for each open panel

### DIFF
--- a/VirtualUI/Source/Installer/VMInstallationViewModel.swift
+++ b/VirtualUI/Source/Installer/VMInstallationViewModel.swift
@@ -449,7 +449,7 @@ final class VMInstallationViewModel: ObservableObject {
     }
 
     func selectInstallFile() {
-        guard let url = NSOpenPanel.run(accepting: selectedSystemType.supportedRestoreImageTypes) else {
+        guard let url = NSOpenPanel.run(accepting: selectedSystemType.supportedRestoreImageTypes, defaultDirectoryKey: "restoreImage") else {
             return
         }
 

--- a/VirtualUI/Source/Settings/PreferencesView.swift
+++ b/VirtualUI/Source/Settings/PreferencesView.swift
@@ -69,7 +69,7 @@ public struct PreferencesView: View {
     }
 
     private func showOpenPanel() {
-        guard let newURL = NSOpenPanel.run(accepting: [.folder], directoryURL: settings.libraryURL) else {
+        guard let newURL = NSOpenPanel.run(accepting: [.folder], directoryURL: settings.libraryURL, defaultDirectoryKey: "library") else {
             return
         }
 

--- a/VirtualUI/Source/VM Configuration/Sections/Sharing/SharedFoldersManagementView.swift
+++ b/VirtualUI/Source/VM Configuration/Sections/Sharing/SharedFoldersManagementView.swift
@@ -174,7 +174,7 @@ struct SharedFoldersManagementView: View {
     }
 
     private func addFolder() {
-        guard let newFolderURL = NSOpenPanel.run(accepting: [.folder]) else {
+        guard let newFolderURL = NSOpenPanel.run(accepting: [.folder], defaultDirectoryKey: "sharedFolders") else {
             return
         }
 

--- a/VirtualUI/Source/VM Configuration/Sections/Storage/StorageDeviceDetailView.swift
+++ b/VirtualUI/Source/VM Configuration/Sections/Storage/StorageDeviceDetailView.swift
@@ -228,7 +228,7 @@ struct StorageDeviceDetailView: View {
     }
     
     private func selectCustomImage() {
-        guard let url = NSOpenPanel.run(accepting: [.diskImage]) else {
+        guard let url = NSOpenPanel.run(accepting: [.diskImage], defaultDirectoryKey: "storageCustomImage") else {
             return
         }
         


### PR DESCRIPTION
This addresses the issue reported in #266 by allowing each open panel in the app to have a custom defaults key associated with it, so that the app always remembers the last directory used for each type of file/directory selection that's available.