### PR TITLE
Use XML format for stored plist

### DIFF
--- a/VirtualCore/Source/Models/VBVirtualMachine.swift
+++ b/VirtualCore/Source/Models/VBVirtualMachine.swift
@@ -172,10 +172,13 @@ public extension VBVirtualMachine {
         guard !ProcessInfo.isSwiftUIPreview else { return }
         #endif
         
-        let configData = try PropertyListEncoder().encode(configuration)
+        let plistEncoder = PropertyListEncoder()
+        plistEncoder.outputFormat = PropertyListSerialization.PropertyListFormat.xml
+        
+        let configData = try plistEncoder.encode(configuration)
         try write(configData, forMetadataFileNamed: Self.configurationFilename)
 
-        let metaData = try PropertyListEncoder().encode(metadata)
+        let metaData = try plistEncoder.encode(metadata)
         try write(metaData, forMetadataFileNamed: Self.metadataFilename)
 
         if let installRestoreData {


### PR DESCRIPTION
Store both `Config.plist` and `Metadata.plist` in a `.vbvm` bundle in XML format to make it easier to analyse and modify those files.

Editing `Config.plist` manually by hand is necessary to unlock "hidden" features of VirtualBuddy such as configuring multiple NICs on the virtual machine.