### PR TITLE
various: fix miscellaneous typos

### DIFF
--- a/DeepLinkSecurity/Source/Storage/KeychainDeepLinkAuthStore.swift
+++ b/DeepLinkSecurity/Source/Storage/KeychainDeepLinkAuthStore.swift
@@ -30,7 +30,7 @@ public final actor KeychainDeepLinkAuthStore: DeepLinkAuthStore {
                 let response = try decoder.decode(KeychainAuthorizationResponse.self, from: authData)
 
                 do {
-                    /// The mere existance of the response in the keychain doesn't automatically mean the decision should be honored.
+                    /// The mere existence of the response in the keychain doesn't automatically mean the decision should be honored.
                     /// When written to the keychain, responses are signed with a private key.
                     /// When read from the keychain, the app verifies the stored signature against the corresponding public key,
                     /// ensuring that this response was written by an app that has permission to access this app's private key item from the keychain.

--- a/DeepLinkSecurity/Source/UI/DeepLinkAuthUI.swift
+++ b/DeepLinkSecurity/Source/UI/DeepLinkAuthUI.swift
@@ -4,7 +4,7 @@ public protocol DeepLinkAuthUI: AnyObject {
     /// Return ``DeepLinkClientAuthorization/authorized`` if the user has allowed the client to open deep links in the app.
     /// 
     /// If this method throws, then the auth store is not modified and the user will be prompted again the next time the same client
-    /// attepts to open a deep link in the app.
+    /// attempts to open a deep link in the app.
     ///
     /// If this method returns ``DeepLinkClientAuthorization/denied``, then the auth store will be modified and future
     /// requests from the same client will be rejected without a prompt.


### PR DESCRIPTION
Fixes two minor typos. This ignores `shownPanelOnFirstLauch` in `GuestAppDelegate.swift`.