### PR TITLE
Fixed Linux VM always showing install recovery alert

### DIFF
--- a/VirtualCore/Source/Models/VBVirtualMachine.swift
+++ b/VirtualCore/Source/Models/VBVirtualMachine.swift
@@ -114,7 +114,8 @@ extension VBVirtualMachine {
     }
 
     public var needsInstall: Bool {
-        !metadata.installFinished || !FileManager.default.fileExists(atPath: hardwareModelURL.path)
+        guard configuration.systemType == .mac else { return false }
+        return !metadata.installFinished || !FileManager.default.fileExists(atPath: hardwareModelURL.path)
     }
 
 }


### PR DESCRIPTION
Linux VMs are not "installed", they're booted from the install media after creation, so the installation alert is only relevant to Mac VMs.