### PR TITLE
Add an option to mount Rosetta on Linux guests

### DIFF
--- a/VirtualCore/Source/Definitions/PreviewSupport.swift
+++ b/VirtualCore/Source/Definitions/PreviewSupport.swift
@@ -68,6 +68,12 @@ public extension VBMacConfiguration {
         return mSelf
     }
     
+    var linuxVirtualMachine: Self {
+        var mSelf = self
+        mSelf.systemType = .linux
+        return mSelf
+    }
+    
 }
 
 public extension VZVirtualMachine {

--- a/VirtualCore/Source/Models/Configuration/ConfigurationModels+Validation.swift
+++ b/VirtualCore/Source/Models/Configuration/ConfigurationModels+Validation.swift
@@ -7,6 +7,7 @@
 
 import Cocoa
 import UniformTypeIdentifiers
+import Virtualization
 
 public extension VBMacConfiguration {
     
@@ -64,6 +65,22 @@ public extension VBMacConfiguration {
         }
     }()
 
+    static let rosettaSupported: Bool = {
+        if #available(macOS 13.0, *) {
+            return VZLinuxRosettaDirectoryShare.availability != VZLinuxRosettaAvailability.notSupported
+        } else {
+            return false
+        }
+    }()
+
+    static func rosettaInstalled() -> Bool {
+        if #available(macOS 13.0, *) {
+            return VZLinuxRosettaDirectoryShare.availability == VZLinuxRosettaAvailability.installed
+        } else {
+            return false
+        }
+    }
+
     static let fileSharingNotice: String = {
         let tip = "For previous OS versions, you can use the standard macOS file sharing feature in System Preferences > Sharing."
 
@@ -73,6 +90,18 @@ public extension VBMacConfiguration {
             return "File sharing requires both the host Mac and the virtual machine to be running macOS 13 or later. \(tip)"
         }
     }()
+
+    static func rosettaSharingNotice() -> String? {
+        if rosettaSupported {
+            if rosettaInstalled() {
+                return nil
+            } else {
+                return "Rosetta is not installed. Run `softwareupdate --install-rosetta` to install Rosetta."
+            }
+        } else {
+            return "Rosetta for Linux requires the host Mac to be running macOS 13 or later."
+        }
+    }
 }
 
 public extension VBMacConfiguration.SupportState {
@@ -198,6 +227,8 @@ public extension VBGuestType {
     var supportsKeyboardCustomization: Bool { self == .mac }
 
     var supportsDisplayPPI: Bool { self == .mac }
+
+    var supportsRosettaMount: Bool { self == .linux }
 
     var supportedRestoreImageTypes: Set<UTType> {
         switch self {

--- a/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
+++ b/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
@@ -45,6 +45,9 @@ public struct VBMacConfiguration: Hashable, Codable {
     @DecodableDefault.True
     public var guestAdditionsEnabled = true
 
+    @DecodableDefault.False
+    public var rosettaSharingEnabled = false
+
     @DecodableDefault.True public var captureSystemKeys = true
 
     public var hasSharedFolders: Bool { !sharedFolders.filter(\.isEnabled).isEmpty }
@@ -334,7 +337,9 @@ public struct VBSharedFolder: Identifiable, Hashable, Codable {
     /// mkdir -p ~/Desktop/VirtualBuddyShared && mount -t virtiofs VirtualBuddyShared ~/Desktop/VirtualBuddyShared
     /// ```
     public static let virtualBuddyShareName = "VirtualBuddyShared"
-    
+
+    public static let rosettaShareName = "Rosetta"
+
     public init(id: UUID = UUID(), url: URL, isEnabled: Bool = true, isReadOnly: Bool = false, customMountPointName: String? = nil) {
         self.id = id
         self.url = url

--- a/VirtualUI/Source/VM Configuration/Sections/Sharing/SharedFoldersManagementView.swift
+++ b/VirtualUI/Source/VM Configuration/Sections/Sharing/SharedFoldersManagementView.swift
@@ -63,6 +63,22 @@ struct SharedFoldersManagementView: View {
             Text(VBMacConfiguration.fileSharingNotice)
                 .font(.caption)
                 .foregroundColor(.yellow)
+
+            if configuration.systemType == .linux {
+                let rosettaToggleBind = if VBMacConfiguration.rosettaSupported {
+                    $configuration.rosettaSharingEnabled
+                } else {
+                    Binding.constant(false)
+                }
+                Toggle("Share Rosetta for Linux", isOn: rosettaToggleBind)
+                    .disabled(!VBMacConfiguration.rosettaSupported)
+
+                if let rosettaSharingNotice = VBMacConfiguration.rosettaSharingNotice() {
+                    Text(rosettaSharingNotice)
+                        .font(.caption)
+                        .foregroundColor(.yellow)
+                }
+            }
         }
         .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didMountNotification)) { note in
             availabilityProvider.refreshAvailabilityIfNeeded(with: note)
@@ -137,16 +153,57 @@ struct SharedFoldersManagementView: View {
     
     @ViewBuilder
     private var mountTip: some View {
-        Text("""
+        let tooltipCommon = """
         To make your shared folders available in the virtual machine,
         run the following command in Terminal (Applications > Utilities > Terminal):
-        
+
         ```
         mkdir -p ~/Desktop/VirtualBuddyShared && mount -t virtiofs VirtualBuddyShared ~/Desktop/VirtualBuddyShared
         ```
-        
+
         A folder named "VirtualBuddyShared" will show up on the Desktop.
-        """)
+        """
+
+        let rosettaVm = VBMacConfiguration.rosettaSupported && configuration.systemType == .linux
+
+        let tooltipRosetta = if rosettaVm {
+            """
+
+
+            To make Rosetta binaries available in the Linux virtual machine,
+            run the following command in the Linux guest's Terminal:
+
+            ```
+            mount -t virtiofs Rosetta /mnt
+            ```
+
+            The Rosetta binaries will be ready in `/mnt`. Follow [this instruction](https://developer.apple.com/documentation/virtualization/running_intel_binaries_in_linux_vms_with_rosetta#3978489) to allow x86-64 binaries to be run on the Linux guest.
+            """
+        } else {
+            ""
+        }
+        let tooltipRosettaInstall = if rosettaVm && !VBMacConfiguration.rosettaInstalled() {
+                """
+
+
+                Rosetta cannot be used unless installed on the host.
+                To install Rosetta, run the following command in host's Terminal:
+
+                ```
+                softwareupdate --install-rosetta
+                ```
+                """
+        } else {
+            ""
+        }
+
+        let tooltipTexts = [tooltipCommon, tooltipRosetta, tooltipRosettaInstall].joined()
+
+        let tooltipAttributedText = try! AttributedString(
+            markdown: tooltipTexts,
+            options: AttributedString.MarkdownParsingOptions(interpretedSyntax:.inlineOnlyPreservingWhitespace)
+        )
+        Text(tooltipAttributedText)
         .textSelection(.enabled)
         .foregroundColor(.white)
         .padding()

--- a/VirtualUI/Source/VM Configuration/Sections/Sharing/SharedFoldersManagementView.swift
+++ b/VirtualUI/Source/VM Configuration/Sections/Sharing/SharedFoldersManagementView.swift
@@ -74,7 +74,7 @@ struct SharedFoldersManagementView: View {
                     .disabled(!VBMacConfiguration.rosettaSupported)
 
                 if let rosettaSharingNotice = VBMacConfiguration.rosettaSharingNotice() {
-                    Text(rosettaSharingNotice)
+                    Text(try! AttributedString(markdown: rosettaSharingNotice))
                         .font(.caption)
                         .foregroundColor(.yellow)
                 }

--- a/VirtualUI/Source/VM Configuration/Sections/Sharing/SharingConfigurationView.swift
+++ b/VirtualUI/Source/VM Configuration/Sections/Sharing/SharingConfigurationView.swift
@@ -54,6 +54,10 @@ struct SharingConfigurationView_Previews: PreviewProvider {
     static var previews: some View {
         _ConfigurationSectionPreview { SharingConfigurationView(configuration: $0) }
 
+        _ConfigurationSectionPreview(.preview.linuxVirtualMachine) {
+            SharingConfigurationView(configuration: $0) }
+            .previewDisplayName("Linux Sharing Configuration View")
+
         _ConfigurationSectionPreview(.preview.removingSharedFolders) { SharingConfigurationView(configuration: $0) }
             .previewDisplayName("Empty")
     }

--- a/VirtualUI/Source/VM Configuration/VMConfigurationView.swift
+++ b/VirtualUI/Source/VM Configuration/VMConfigurationView.swift
@@ -49,6 +49,8 @@ struct VMConfigurationView: View {
 
     private var showDisplayPPISelection: Bool { systemType.supportsDisplayPPI }
     
+    private var showRosettaMountSelection: Bool { systemType.supportsRosettaMount }
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             if showBootDiskSection {


### PR DESCRIPTION
This PR add an option to enable Rosetta for Linux guests. This feature is introduced in macOS 13. Full information about this feature [here](https://developer.apple.com/documentation/virtualization/running_intel_binaries_in_linux_vms_with_rosetta).

This PR only add the **Share Rosetta for Linux** option under the **Sharing** section in Linux VM settings, which when checked will allow the guest VM to `mount -t virtiofs Rosetta (mountpoint)` to mount the Rosetta binary.

This PR does not include:
- The script required to setup Rosetta so that it can be directly used to execute x86_64 binaries.
- Prompting user to download and install Rosetta. Instead, user will be asked to install Rosetta will be shown in the warning section and the help section of the **Sharing** VM settings section.