### PR TITLE
Fix window resizing templates behaviour

### DIFF
--- a/VirtualUI/Source/Components/HostingWindowController/VBRestorableWindow+Resizing.swift
+++ b/VirtualUI/Source/Components/HostingWindowController/VBRestorableWindow+Resizing.swift
@@ -14,39 +14,39 @@ extension VBRestorableWindow {
     func resize(to size: VirtualMachineSessionUI.WindowSize, for display: VBDisplayDevice) {
         guard let screen else { return }
 
-        let targetSize: CGSize
+        let targetWidth: CGFloat
+        let targetHeight: CGFloat
         let displaySize = CGSize(width: display.width, height: display.height)
-        let availableHeight: CGFloat = screen.visibleFrame.height - screen.visibleFrame.origin.y / 2
+        let toolbarHeight: CGFloat = frameRect(forContentRect: NSRect()).height
+        let availableHeight: CGFloat = screen.visibleFrame.height - screen.visibleFrame.origin.y / 2 - toolbarHeight
 
         switch size {
         case .pointAccurate:
-            targetSize = CGSize(
-                width: CGFloat(display.width) * 72.0 / CGFloat(display.pixelsPerInch),
-                height: CGFloat(display.height) * 72.0 / CGFloat(display.pixelsPerInch)
-            )
+            let referencePpi = screen.backingScaleFactor * 72.0
+            targetWidth = CGFloat(display.width) * referencePpi / CGFloat(display.pixelsPerInch)
+            targetHeight = CGFloat(display.height) * referencePpi / CGFloat(display.pixelsPerInch)
         case .pixelAccurate:
-            targetSize = CGSize(
-                width: CGFloat(display.width) * screen.dpi.width / CGFloat(display.pixelsPerInch),
-                height: CGFloat(display.height) * screen.dpi.height / CGFloat(display.pixelsPerInch)
-            )
+            targetWidth = CGFloat(display.width) / screen.backingScaleFactor
+            targetHeight = CGFloat(display.height) / screen.backingScaleFactor
         case .fitScreen:
             let windowAspectRatio = displaySize.width / displaySize.height
             let containerAspectRatio = screen.visibleFrame.width / availableHeight
             let widthFirst = windowAspectRatio > containerAspectRatio
 
-            let windowWidth: CGFloat
-            let windowHeight: CGFloat
-
             if widthFirst {
-                windowWidth = screen.visibleFrame.width
-                windowHeight = windowWidth / windowAspectRatio
+                targetWidth = screen.visibleFrame.width
+                targetHeight = targetWidth / windowAspectRatio
             } else {
-                windowHeight = availableHeight
-                windowWidth = windowHeight * windowAspectRatio
+                targetHeight = availableHeight
+                targetWidth = availableHeight * windowAspectRatio
             }
-
-            targetSize = CGSize(width: windowWidth, height: windowHeight)
         }
+
+        // clamped targetSize to the available screen's real estate
+        let targetSize = CGSize(
+            width: min(targetWidth, screen.visibleFrame.width),
+            height: min(targetHeight, availableHeight)
+        )
 
         let targetRect = NSRect(
             x: screen.visibleFrame.origin.x + screen.visibleFrame.width / 2 - targetSize.width / 2,

--- a/VirtualUI/Source/Components/HostingWindowController/VBRestorableWindow+Resizing.swift
+++ b/VirtualUI/Source/Components/HostingWindowController/VBRestorableWindow+Resizing.swift
@@ -22,9 +22,8 @@ extension VBRestorableWindow {
 
         switch size {
         case .pointAccurate:
-            let referencePpi = screen.backingScaleFactor * 72.0
-            targetWidth = CGFloat(display.width) * referencePpi / CGFloat(display.pixelsPerInch)
-            targetHeight = CGFloat(display.height) * referencePpi / CGFloat(display.pixelsPerInch)
+            targetWidth = CGFloat(display.width)
+            targetHeight = CGFloat(display.height)
         case .pixelAccurate:
             targetWidth = CGFloat(display.width) / screen.backingScaleFactor
             targetHeight = CGFloat(display.height) / screen.backingScaleFactor

--- a/VirtualUI/Source/Components/HostingWindowController/VBRestorableWindow+Resizing.swift
+++ b/VirtualUI/Source/Components/HostingWindowController/VBRestorableWindow+Resizing.swift
@@ -18,7 +18,8 @@ extension VBRestorableWindow {
         let targetHeight: CGFloat
         let displaySize = CGSize(width: display.width, height: display.height)
         let toolbarHeight: CGFloat = frameRect(forContentRect: NSRect()).height
-        let availableHeight: CGFloat = screen.visibleFrame.height - screen.visibleFrame.origin.y / 2 - toolbarHeight
+        // screen.visibleFrame.height is a "net" value after taking into account menu bar, dock, etc.
+        let availableHeight: CGFloat = screen.visibleFrame.height - toolbarHeight
 
         switch size {
         case .pointAccurate:


### PR DESCRIPTION
This PR updates the window sizing templates to behave as follows:

- **Pixel Accurate** = resize the view so that one pixel occupies one physical display pixel.
- **Point Accurate** = resize the view so that one pixel occupies one logical point relative to physical display's PPI (e.g. let's give the configured resolution as-is to NSWindow and let it handle the rest).
- **Fit Screen** = takes into account toolbar height when computing the aspect ratio.

Additionally, this PR puts a clamp to the resulting value so that the resulting window size does not exceed the available screen's real estate (ensuring that everything including the toolbar is always visible).

Note that the value represented by `deviceDescription[NSDeviceDescriptionKey.resolution]` is never accurate: it is either 72 dpi for regular displays or 144 dpi for retina displays. Instead, we can use `NSScreen.backingScaleFactor` to accurately determine if the display is retina (value of `2.0`) or regular (value of `1.0`).