### PR TITLE
Do not treat VM as stopped after calling requestStop

### DIFF
--- a/VirtualCore/Source/Virtualization/VMController.swift
+++ b/VirtualCore/Source/Virtualization/VMController.swift
@@ -146,8 +146,6 @@ public final class VMController: ObservableObject {
             let instance = try ensureInstance()
 
             try await instance.stop()
-
-            state = .stopped(nil)
         }
 
         unhideCursor()

--- a/VirtualCore/Source/Virtualization/VMInstance.swift
+++ b/VirtualCore/Source/Virtualization/VMInstance.swift
@@ -259,8 +259,6 @@ public final class VMInstance: NSObject, ObservableObject {
         let vm = try ensureVM()
         
         try vm.requestStop()
-
-        library.bootedMachineIdentifiers.remove(virtualMachineModel.id)
     }
     
     func forceStop() async throws {

--- a/VirtualUI/Source/Session/Components/VirtualMachineControls.swift
+++ b/VirtualUI/Source/Session/Components/VirtualMachineControls.swift
@@ -59,7 +59,7 @@ struct VirtualMachineControls<Controller: VirtualMachineStateController>: View {
                         try await controller.stop()
                     }
                 } label: {
-                    Image(systemName: "stop")
+                    Image(systemName: "power")
                 }
             }
         }


### PR DESCRIPTION
The `VZVirtualMachine.requestStop` function is akin to pressing the power button on a real computer: it is up to the guest machine on how to respond to that, and they might not necessarily shutdown. For example, on macOS, doing that will display a dialog where the user can choose to restart, shutdown, or cancel the operation. On Linux, it entirely depends on what `init` program would like to do: it can completely ignore such requests for example.

This PR updates the code to reflect that behaviour, and also updates the toolbar icon to use the Power button icon.