### PR TITLE
Use new Virtualization SPI for screenshots, new abstraction

### DIFF
--- a/VirtualBuddy.xcodeproj/project.pbxproj
+++ b/VirtualBuddy.xcodeproj/project.pbxproj
@@ -197,6 +197,10 @@
 		F4E7680A29B64C590075A897 /* GuestTypePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E7680929B64C590075A897 /* GuestTypePicker.swift */; };
 		F4E7680D29B651220075A897 /* VirtualUI.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F4E7680C29B651220075A897 /* VirtualUI.xcassets */; };
 		F4E7680F29B655DD0075A897 /* InstallMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E7680E29B655DD0075A897 /* InstallMethod.swift */; };
+		F4E7DF852BB30D8A00C459FC /* VMScreenshotTimingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E7DF842BB30D8A00C459FC /* VMScreenshotTimingController.swift */; };
+		F4E7DF872BB30E1200C459FC /* NSImage+VMScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E7DF862BB30E1200C459FC /* NSImage+VMScreenshot.swift */; };
+		F4E7DF8A2BB3141F00C459FC /* VZGraphicsDisplay+Screenshot.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E7DF882BB3141F00C459FC /* VZGraphicsDisplay+Screenshot.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4E7DF8B2BB3141F00C459FC /* VZGraphicsDisplay+Screenshot.m in Sources */ = {isa = PBXBuildFile; fileRef = F4E7DF892BB3141F00C459FC /* VZGraphicsDisplay+Screenshot.m */; };
 		F4F5A36029B6324A00F5A12E /* SoftwareVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F5A35F29B6324A00F5A12E /* SoftwareVersion.swift */; };
 		F4F9B416284CE0F900F21737 /* VBSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F9B415284CE0F900F21737 /* VBSettings.swift */; };
 		F4F9B418284CE12000F21737 /* VBSettingsContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F9B417284CE12000F21737 /* VBSettingsContainer.swift */; };
@@ -528,6 +532,10 @@
 		F4E7680929B64C590075A897 /* GuestTypePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestTypePicker.swift; sourceTree = "<group>"; };
 		F4E7680C29B651220075A897 /* VirtualUI.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = VirtualUI.xcassets; sourceTree = "<group>"; };
 		F4E7680E29B655DD0075A897 /* InstallMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallMethod.swift; sourceTree = "<group>"; };
+		F4E7DF842BB30D8A00C459FC /* VMScreenshotTimingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMScreenshotTimingController.swift; sourceTree = "<group>"; };
+		F4E7DF862BB30E1200C459FC /* NSImage+VMScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSImage+VMScreenshot.swift"; sourceTree = "<group>"; };
+		F4E7DF882BB3141F00C459FC /* VZGraphicsDisplay+Screenshot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "VZGraphicsDisplay+Screenshot.h"; sourceTree = "<group>"; };
+		F4E7DF892BB3141F00C459FC /* VZGraphicsDisplay+Screenshot.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "VZGraphicsDisplay+Screenshot.m"; sourceTree = "<group>"; };
 		F4F5A35F29B6324A00F5A12E /* SoftwareVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareVersion.swift; sourceTree = "<group>"; };
 		F4F9B415284CE0F900F21737 /* VBSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VBSettings.swift; sourceTree = "<group>"; };
 		F4F9B417284CE12000F21737 /* VBSettingsContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VBSettingsContainer.swift; sourceTree = "<group>"; };
@@ -1072,6 +1080,7 @@
 		F4A21BEF28032FB0001072B8 /* Virtualization */ = {
 			isa = PBXGroup;
 			children = (
+				F4E7DF832BB30D8200C459FC /* Screenshot */,
 				F4A21BF028032FBD001072B8 /* Helpers */,
 				F4A21BF128032FD8001072B8 /* VMLibraryController.swift */,
 				F46FFBAB28059FF600D61023 /* VMInstance.swift */,
@@ -1385,6 +1394,17 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		F4E7DF832BB30D8200C459FC /* Screenshot */ = {
+			isa = PBXGroup;
+			children = (
+				F4E7DF842BB30D8A00C459FC /* VMScreenshotTimingController.swift */,
+				F4E7DF862BB30E1200C459FC /* NSImage+VMScreenshot.swift */,
+				F4E7DF882BB3141F00C459FC /* VZGraphicsDisplay+Screenshot.h */,
+				F4E7DF892BB3141F00C459FC /* VZGraphicsDisplay+Screenshot.m */,
+			);
+			path = Screenshot;
+			sourceTree = "<group>";
+		};
 		F4F9B414284CE0DC00F21737 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -1432,6 +1452,7 @@
 			files = (
 				F4BE9C6827FF053A00B648F8 /* VirtualCore.h in Headers */,
 				F4BE9C8627FF140F00B648F8 /* VirtualizationPrivate.h in Headers */,
+				F4E7DF8A2BB3141F00C459FC /* VZGraphicsDisplay+Screenshot.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1635,7 +1656,7 @@
 					};
 					F4BE9C6427FF053A00B648F8 = {
 						CreatedOnToolsVersion = 13.3;
-						LastSwiftMigration = 1330;
+						LastSwiftMigration = 1530;
 					};
 					F4C189DF2848F59F00335EC7 = {
 						CreatedOnToolsVersion = 13.4;
@@ -1906,6 +1927,7 @@
 				F41725762887758A004FF8A7 /* RandomNameGenerator.swift in Sources */,
 				F44C00FB2889CE1600640BF5 /* VBVirtualMachine+Virtualization.swift in Sources */,
 				F4F9B418284CE12000F21737 /* VBSettingsContainer.swift in Sources */,
+				F4E7DF872BB30E1200C459FC /* NSImage+VMScreenshot.swift in Sources */,
 				F48E0D0C2888760D0080DDFA /* VBMacDevice+Storage.swift in Sources */,
 				F465C3AE284F93A5006E9ED4 /* VBAPIClient.swift in Sources */,
 				F4D725FE286677B8001818F7 /* VBVirtualMachine+Metadata.swift in Sources */,
@@ -1921,6 +1943,7 @@
 				F465C3B8284FA252006E9ED4 /* VBDownloader.swift in Sources */,
 				F4A21BF228032FD8001072B8 /* VMLibraryController.swift in Sources */,
 				F49A68E12884917E00A17582 /* ConfigurationModels.swift in Sources */,
+				F4E7DF8B2BB3141F00C459FC /* VZGraphicsDisplay+Screenshot.m in Sources */,
 				F4C237502888AF67001FF286 /* LogStreamer.swift in Sources */,
 				F4F9B41A284CE37C00F21737 /* Logging.swift in Sources */,
 				F4B5C5D728870619005AA632 /* ConfigurationModels+Validation.swift in Sources */,
@@ -1931,6 +1954,7 @@
 				F443620A29B7947A00745B43 /* GuestAdditionsDiskImage.swift in Sources */,
 				F4BE9C7827FF055100B648F8 /* MacOSVirtualMachineConfigurationHelper.swift in Sources */,
 				F4F5A36029B6324A00F5A12E /* SoftwareVersion.swift in Sources */,
+				F4E7DF852BB30D8A00C459FC /* VMScreenshotTimingController.swift in Sources */,
 				F4510A782AE2A16F00E24DD9 /* WeakReference.swift in Sources */,
 				F46FFBAC28059FF600D61023 /* VMInstance.swift in Sources */,
 				F465C3B0284F9660006E9ED4 /* VBRestoreImagesResponse.swift in Sources */,

--- a/VirtualCore/Source/Headers/VirtualizationPrivate.h
+++ b/VirtualCore/Source/Headers/VirtualizationPrivate.h
@@ -107,4 +107,10 @@ __attribute__((weak_import))
 
 @end
 
+@interface VZGraphicsDisplay (Private)
+
+- (void)_takeScreenshotWithCompletionHandler:(void(^__nonnull)(id __nullable image, id __nullable error))completion NS_SWIFT_UI_ACTOR API_AVAILABLE(macos(14.0));
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/VirtualCore/Source/Models/VBVirtualMachine+Screenshot.swift
+++ b/VirtualCore/Source/Models/VBVirtualMachine+Screenshot.swift
@@ -16,8 +16,8 @@ public extension VBVirtualMachine {
     }
 
     static let thumbnailProperties = [
-        kCGImageDestinationLossyCompressionQuality: 0.7,
-        kCGImageDestinationImageMaxPixelSize: 640
+        kCGImageDestinationLossyCompressionQuality: 0.9,
+        kCGImageDestinationImageMaxPixelSize: 1024
     ] as CFDictionary
 
     func thumbnailImage() -> NSImage? {

--- a/VirtualCore/Source/Virtualization/Screenshot/NSImage+VMScreenshot.swift
+++ b/VirtualCore/Source/Virtualization/Screenshot/NSImage+VMScreenshot.swift
@@ -1,0 +1,22 @@
+import Cocoa
+import Virtualization
+
+@available(macOS 14.0, *)
+public extension NSImage {
+    @MainActor
+    static func screenshot(from virtualMachine: VZVirtualMachine) async throws -> NSImage {
+        guard let device = virtualMachine.graphicsDevices.first else {
+            throw Failure("Can't screenshot a virtual machine without a graphics device.")
+        }
+        guard let display = device.displays.first else {
+            throw Failure("Can't screenshot a virtual machine without a display.")
+        }
+
+        return try await screenshot(from: display)
+    }
+
+    @MainActor
+    static func screenshot(from display: VZGraphicsDisplay) async throws -> NSImage {
+        try await display.vb_takeScreenshot()
+    }
+}

--- a/VirtualCore/Source/Virtualization/Screenshot/VMScreenshotTimingController.swift
+++ b/VirtualCore/Source/Virtualization/Screenshot/VMScreenshotTimingController.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Provides scheduling for periodic VM screenshots.
+/// This is used by `VMScreenshotter` in `VirtualUI`.
+public final class VMScreenshotTimingController {
+    private var timer: Timer?
+
+    public let interval: TimeInterval
+    private let onTimerFired: () async throws -> Void
+
+    public init(interval: TimeInterval, onTimerFired: @escaping () async throws -> Void) {
+        assert(interval > 1, "The minimum interval is 1 second")
+
+        self.interval = max(1, interval)
+        self.onTimerFired = onTimerFired
+    }
+
+    public func activate() {
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true, block: { [weak self] _ in
+            self?.timerFired()
+        })
+    }
+
+    public func invalidate() {
+        pendingTask?.cancel()
+        pendingTask = nil
+
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private var pendingTask: Task<(), Error>?
+
+    private func timerFired() {
+        pendingTask?.cancel()
+
+        pendingTask = Task.detached(priority: .utility) { [weak self] in
+            guard let self else { return }
+            try await self.onTimerFired()
+        }
+    }
+
+    deinit {
+        #if DEBUG
+        print("\(String(describing: self)) 👋🏻")
+        #endif
+    }
+}

--- a/VirtualCore/Source/Virtualization/Screenshot/VZGraphicsDisplay+Screenshot.h
+++ b/VirtualCore/Source/Virtualization/Screenshot/VZGraphicsDisplay+Screenshot.h
@@ -1,0 +1,13 @@
+#import <Virtualization/Virtualization.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface VZGraphicsDisplay (Screenshot)
+
+/// Wraps Virtualization SPI to make it safer to call from Swift.
+/// Checks for SPI availability and that the completion block types match the ones we expect.
+- (void)vb_takeScreenshotWithCompletionHandler:(void(^_Nonnull)(NSImage *_Nullable image, NSError *_Nullable error))completion NS_SWIFT_UI_ACTOR API_AVAILABLE(macos(14.0));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/VirtualCore/Source/Virtualization/Screenshot/VZGraphicsDisplay+Screenshot.m
+++ b/VirtualCore/Source/Virtualization/Screenshot/VZGraphicsDisplay+Screenshot.m
@@ -1,0 +1,43 @@
+#import "VZGraphicsDisplay+Screenshot.h"
+
+#import <VirtualCore/VirtualizationPrivate.h>
+
+@implementation VZGraphicsDisplay (Screenshot)
+
+- (BOOL)vb_supportsScreenshotSPI
+{
+    static dispatch_once_t onceToken;
+    static BOOL supports;
+    dispatch_once(&onceToken, ^{
+        supports = [self respondsToSelector:NSSelectorFromString(@"_takeScreenshotWithCompletionHandler:")];
+    });
+    return supports;
+}
+
+- (void)vb_takeScreenshotWithCompletionHandler:(void(^_Nonnull)(NSImage *_Nullable image, NSError *_Nullable error))completion
+{
+    #define failure( msg ) [NSError errorWithDomain:@"screenshot" code:1 userInfo:@{NSLocalizedDescriptionKey: msg}]
+
+    if (![self vb_supportsScreenshotSPI]) {
+        completion(nil, failure(@"VZGraphicsDisplay doesn't have the _takeScreenshotWithCompletionHandler: method"));
+        return;
+    }
+
+    [self _takeScreenshotWithCompletionHandler:^(id  _Nullable image, id  _Nullable error) {
+        if (image) {
+            if (![image isKindOfClass:[NSImage class]]) {
+                completion(nil, failure(@"Unexpected image type"));
+            } else {
+                completion(image, nil);
+            }
+        } else {
+            if ([error isKindOfClass:[NSError class]]) {
+                completion(nil, error);
+            } else {
+                completion(nil, failure(@"Unexpected result: no image nor error"));
+            }
+        }
+    }];
+}
+
+@end

--- a/VirtualCore/VirtualCore.h
+++ b/VirtualCore/VirtualCore.h
@@ -16,3 +16,4 @@ FOUNDATION_EXPORT const unsigned char VirtualCoreVersionString[];
 // In this header, you should import all the public headers of your framework using statements like #import <VirtualCore/PublicHeader.h>
 
 #import <VirtualCore/VirtualizationPrivate.h>
+#import <VirtualCore/VZGraphicsDisplay+Screenshot.h>

--- a/VirtualUI/Source/Session/Components/SwiftUIVMView.swift
+++ b/VirtualUI/Source/Session/Components/SwiftUIVMView.swift
@@ -109,7 +109,7 @@ final class VMViewController: NSViewController {
         
         window.makeFirstResponder(vmView)
         
-        screenshotter.activate(with: view)
+        screenshotter.activate(with: view, vm: vmView.virtualMachine)
     }
 
     override func viewWillDisappear() {

--- a/VirtualUI/Source/Session/Components/VMScreenshotter.swift
+++ b/VirtualUI/Source/Session/Components/VMScreenshotter.swift
@@ -3,6 +3,7 @@ import Combine
 import OSLog
 import CoreImage
 import AVFoundation
+import VirtualCore
 
 final class VMScreenshotter {
 
@@ -13,89 +14,63 @@ final class VMScreenshotter {
     let screenshotSubject: Subject
 
     private weak var view: NSView?
-    private let interval: TimeInterval
-    
+    private weak var vm: VZVirtualMachine?
+    private var timingController: VMScreenshotTimingController!
+
     init(interval: TimeInterval, screenshotSubject: Subject) {
-        assert(interval > 1, "The minimum interval is 1 second")
-        
-        self.interval = max(1, interval)
         self.screenshotSubject = screenshotSubject
+        self.timingController = VMScreenshotTimingController(interval: interval) { [weak self] in
+            guard let self else { return }
+            try await self.capture()
+        }
     }
     
-    private var timer: Timer?
-    
-    func activate(with view: NSView) {
+    func activate(with view: NSView, vm: VZVirtualMachine?) {
         invalidate()
         
         self.view = view
-
-        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true, block: { [weak self] _ in
-            self?.timerFired()
-        })
+        self.vm = vm
+        
+        timingController.activate()
     }
     
     func invalidate() {
-        pendingCapture?.cancel()
-        timer?.invalidate()
-        timer = nil
-        
+        timingController.invalidate()
+
         guard let previousScreenshotData else { return }
 
         self.screenshotSubject.send(previousScreenshotData)
     }
-    
-    private func timerFired() {
-        capture()
-    }
-    
+
     // Used to restore to the second-to-last screenshot when the machine shuts down,
     // so as to avoid having the screenshots all be the same (the Dock moving down and no Menu Bar).
     private var previousScreenshotData: Data?
-    
-    private var pendingCapture: Task<(), Error>?
-    
-    func capture() {
-        pendingCapture = Task.detached(priority: .utility) { [weak self] in
-            guard let self = self else { return }
 
-            let data = await MainActor.run {
-                self.takeScreenshot()
-            }
+    func capture() async throws {
+        let data = await takeScreenshot()
 
-            guard let data else { return }
+        guard let data else { return }
 
-            try Task.checkCancellation()
+        try Task.checkCancellation()
 
-            self.previousScreenshotData = data
+        self.previousScreenshotData = data
 
-            try Task.checkCancellation()
-            
-            await MainActor.run {
-                self.screenshotSubject.send(data)
-            }
+        try Task.checkCancellation()
+
+        await MainActor.run {
+            self.screenshotSubject.send(data)
         }
     }
 
     private lazy var context = CIContext()
 
     private let imageOptions: [CFString: Any] = [
-        kCGImageDestinationLossyCompressionQuality: 0.8,
-        kCGImageDestinationImageMaxPixelSize: 2000
+        kCGImageDestinationLossyCompressionQuality: 1,
+        kCGImageDestinationImageMaxPixelSize: 4096
     ]
 
-    @MainActor
-    private func takeScreenshot() -> Data? {
-        guard let view else { return nil }
-        
-        let bounds = view.bounds
-
-        guard bounds.width > 0, bounds.height > 0 else { return nil }
-
-        guard let bitmapRep = view.bitmapImageRepForCachingDisplay(in: bounds) else { return nil }
-
-        view.cacheDisplay(in: bounds, to: bitmapRep)
-
-        guard let cgImage = bitmapRep.cgImage else { return nil }
+    private func takeScreenshot() async -> Data? {
+        guard let cgImage = await takeScreenshotCGImage() else { return nil }
 
         guard let cfData = CFDataCreateMutable(kCFAllocatorDefault, 0) else { return nil }
         guard let destination = CGImageDestinationCreateWithData(cfData, AVFileType.heic.rawValue as CFString, 1, nil) else { return nil }
@@ -109,3 +84,54 @@ final class VMScreenshotter {
 }
 
 extension NSImage: @unchecked Sendable { }
+
+// MARK: - Screenshot Taking
+
+private extension VMScreenshotter {
+    /// Uses AppKit to take the screenshot from the virtual machine view itself.
+    /// This is always used in macOS 13, and can be used in macOS 14 or later if the Virtualization SPI is not available.
+    @MainActor
+    func takeScreenshotUsingView() -> CGImage? {
+        guard let view else { return nil }
+
+        let bounds = view.bounds
+
+        guard bounds.width > 0, bounds.height > 0 else { return nil }
+
+        guard let bitmapRep = view.bitmapImageRepForCachingDisplay(in: bounds) else { return nil }
+
+        view.cacheDisplay(in: bounds, to: bitmapRep)
+
+        guard let cgImage = bitmapRep.cgImage else { return nil }
+
+        return cgImage
+    }
+
+    /// Uses new SPI in Virtualization on macOS 14 to take the screenshot from the `VZVirtualMachine` instance.
+    /// Currently only takes a screenshot from a single display.
+    @available(macOS 14.0, *)
+    func takeScreenshotUsingVirtualizationSPI() async -> CGImage? {
+        do {
+            guard let vm else {
+                throw Failure("VM not available")
+            }
+
+            let image = try await NSImage.screenshot(from: vm)
+
+            return image.cgImage(forProposedRect: nil, context: nil, hints: nil)
+        } catch {
+            logger.error("SPI screenshot failed, falling back to view snapshot. Error: \(error, privacy: .public)")
+            return await takeScreenshotUsingView()
+        }
+    }
+
+    /// Returns a `CGImage` with a screenshot of the VM in its current state,
+    /// using the best available screenshotting method.
+    func takeScreenshotCGImage() async -> CGImage? {
+        if #available(macOS 14.0, *) {
+            return await takeScreenshotUsingVirtualizationSPI()
+        } else {
+            return await takeScreenshotUsingView()
+        }
+    }
+}


### PR DESCRIPTION
The main reason for this change now is that I wanted a way to take screenshots on-demand for the save/restore feature that's in development.

This introduces the following changes:

- Abstracts screenshot timing into `VMScreenshotTimingController`
- Implements an extension on `VZGraphicsDisplay` (`vb_takeScreenshotWithCompletionHandler:`) that wraps the `_takeScreenshotWithCompletionHandler:` SPI so that it can be safely called from Swift
- Adds a couple of `NSImage.screenshot(from:)` static methods that create an `NSImage` from either a `VZVirtualMachine` or a `VZGraphicsDisplay`
- Changes `VMScreenshotter` so that it uses the new timing controller and the new screenshotting method when it's available; if the new method is not available or fails, it falls back to taking a snapshot of the VM view itself
- Increases the compression quality and resolution for screenshots, since using HEIC as introduced in #302 ensures the file sizes stay under control