### PR TITLE
Improved window management

### DIFF
--- a/VirtualBuddy.xcodeproj/project.pbxproj
+++ b/VirtualBuddy.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 		F4E7DF872BB30E1200C459FC /* NSImage+VMScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E7DF862BB30E1200C459FC /* NSImage+VMScreenshot.swift */; };
 		F4E7DF8A2BB3141F00C459FC /* VZGraphicsDisplay+Screenshot.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E7DF882BB3141F00C459FC /* VZGraphicsDisplay+Screenshot.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F4E7DF8B2BB3141F00C459FC /* VZGraphicsDisplay+Screenshot.m in Sources */ = {isa = PBXBuildFile; fileRef = F4E7DF892BB3141F00C459FC /* VZGraphicsDisplay+Screenshot.m */; };
+		F4E7DFCF2BB3587D00C459FC /* VirtualMachineSessionUIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E7DFCE2BB3587D00C459FC /* VirtualMachineSessionUIManager.swift */; };
 		F4F5A36029B6324A00F5A12E /* SoftwareVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F5A35F29B6324A00F5A12E /* SoftwareVersion.swift */; };
 		F4F9B416284CE0F900F21737 /* VBSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F9B415284CE0F900F21737 /* VBSettings.swift */; };
 		F4F9B418284CE12000F21737 /* VBSettingsContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F9B417284CE12000F21737 /* VBSettingsContainer.swift */; };
@@ -536,6 +537,7 @@
 		F4E7DF862BB30E1200C459FC /* NSImage+VMScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSImage+VMScreenshot.swift"; sourceTree = "<group>"; };
 		F4E7DF882BB3141F00C459FC /* VZGraphicsDisplay+Screenshot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "VZGraphicsDisplay+Screenshot.h"; sourceTree = "<group>"; };
 		F4E7DF892BB3141F00C459FC /* VZGraphicsDisplay+Screenshot.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "VZGraphicsDisplay+Screenshot.m"; sourceTree = "<group>"; };
+		F4E7DFCE2BB3587D00C459FC /* VirtualMachineSessionUIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualMachineSessionUIManager.swift; sourceTree = "<group>"; };
 		F4F5A35F29B6324A00F5A12E /* SoftwareVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareVersion.swift; sourceTree = "<group>"; };
 		F4F9B415284CE0F900F21737 /* VBSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VBSettings.swift; sourceTree = "<group>"; };
 		F4F9B417284CE12000F21737 /* VBSettingsContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VBSettingsContainer.swift; sourceTree = "<group>"; };
@@ -781,6 +783,7 @@
 			children = (
 				F42C01562888FC0C00EB15CD /* Components */,
 				F42C01532888FC0C00EB15CD /* Configuration */,
+				F4E7DFCE2BB3587D00C459FC /* VirtualMachineSessionUIManager.swift */,
 				F49AA2C429BA31CC009625F7 /* VirtualMachineSessionUI.swift */,
 				F42C01552888FC0C00EB15CD /* VirtualMachineSessionView.swift */,
 			);
@@ -1837,6 +1840,7 @@
 				F422587E2885E2ED009420AE /* HardwareConfigurationView.swift in Sources */,
 				F48E0D1D288882BD0080DDFA /* AuthenticatingWebView.swift in Sources */,
 				F413696529916F6E002CE8D3 /* StatusItemPanelContentController.swift in Sources */,
+				F4E7DFCF2BB3587D00C459FC /* VirtualMachineSessionUIManager.swift in Sources */,
 				F4561A6828981B4100055289 /* VirtualMachineNameField.swift in Sources */,
 				F413696229916F6E002CE8D3 /* StatusItemButton.swift in Sources */,
 				F49AA2C529BA31CC009625F7 /* VirtualMachineSessionUI.swift in Sources */,

--- a/VirtualBuddy/Bootstrap/VirtualBuddyApp.swift
+++ b/VirtualBuddy/Bootstrap/VirtualBuddyApp.swift
@@ -16,16 +16,16 @@ struct VirtualBuddyApp: App {
     @NSApplicationDelegateAdaptor
     var appDelegate: VirtualBuddyAppDelegate
 
-    @StateObject private var settingsContainer = VBSettingsContainer.current
-    @StateObject private var updateController = SoftwareUpdateController.shared
-    @StateObject private var library = VMLibraryController.shared
-    @StateObject private var sessionManager = VirtualMachineSessionUIManager.shared
+    private var settingsContainer: VBSettingsContainer { appDelegate.settingsContainer }
+    private var updateController: SoftwareUpdateController { appDelegate.updateController }
+    private var library: VMLibraryController { appDelegate.library }
+    private var sessionManager: VirtualMachineSessionUIManager { appDelegate.sessionManager }
 
-    @Environment(\.openCocoaWindow)
+    @Environment(\.openWindow)
     private var openWindow
 
     var body: some Scene {
-        WindowGroup(id: "library") {
+        Window(Text("VirtualBuddy"), id: .vb_libraryWindowID) {
             LibraryView()
                 .onAppearOnce(perform: updateController.activate)
                 .environmentObject(library)
@@ -44,6 +44,12 @@ struct VirtualBuddyApp: App {
             CommandGroup(before: .windowSize) {
                 VirtualMachineWindowCommands()
                     .environmentObject(sessionManager)
+            }
+
+            CommandGroup(after: .windowArrangement) {
+                Button("Library") {
+                    openWindow(id: .vb_libraryWindowID)
+                }
             }
         }
         

--- a/VirtualBuddy/Bootstrap/VirtualBuddyAppDelegate.swift
+++ b/VirtualBuddy/Bootstrap/VirtualBuddyAppDelegate.swift
@@ -10,15 +10,24 @@ import Cocoa
 @_exported import VirtualUI
 import VirtualWormhole
 import DeepLinkSecurity
+import OSLog
 
 #if BUILDING_NON_MANAGED_RELEASE
 #error("Trying to build for release without using the managed scheme. This build won't include managed entitlements. This error is here for Rambo, you may safely comment it out and keep going.")
 #endif
 
+@MainActor
 @objc final class VirtualBuddyAppDelegate: NSObject, NSApplicationDelegate {
-    
+
+    private let logger = Logger(for: VirtualBuddyAppDelegate.self)
+
+    let settingsContainer = VBSettingsContainer.current
+    let updateController = SoftwareUpdateController.shared
+    let library = VMLibraryController.shared
+    let sessionManager = VirtualMachineSessionUIManager.shared
+
     func applicationWillFinishLaunching(_ notification: Notification) {
-        DeepLinkHandler.bootstrap()
+        DeepLinkHandler.bootstrap(updatingWindows: self.updatingWindows(perform:))
 
         NSApp?.appearance = NSAppearance(named: .darkAqua)
     }
@@ -28,12 +37,72 @@ import DeepLinkSecurity
             try? await GuestAdditionsDiskImage.current.installIfNeeded()
         }
     }
-    
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool { false }
+
     @objc func restoreDefaultWindowPosition(_ sender: Any?) {
         guard let window = NSApp?.keyWindow ?? NSApp?.mainWindow else { return }
         
         window.setFrame(.init(x: 0, y: 0, width: 960, height: 600), display: true, animate: false)
         window.center()
     }
-    
+
+    /// `true` if the VirtualBuddy library window was previously closed, but got re-opened due to the app being reactivated.
+    /// 
+    /// This is used to close the library window when opening a file or URL in VirtualBuddy, as we don't want the library window
+    /// to show up whenever a file or URL is opened in the app, it should only show up on launch or when the app is re-opened
+    /// due to other interactions such as clicking the icon in the Dock when there are no other windows visible.
+    private var appReopenCausedLibraryWindowOpen = false
+
+    func application(_ application: NSApplication, open urls: [URL]) {
+        updatingWindows {
+            for url in urls {
+                sessionManager.openVirtualMachine(at: url, library: library)
+            }
+        }
+    }
+
+    func applicationWillBecomeActive(_ notification: Notification) {
+        let visibleWindowCount = NSApplication.shared.windows.filter(\.isVisible).count
+
+        let libraryWindowOpen = isLibraryWindowOpen
+
+        /// If the library window is not currently visible, then its visibility state after leaving this method will be the result of the app being re-opened.
+        appReopenCausedLibraryWindowOpen = !libraryWindowOpen
+
+        logger.debug("willBecomeActive (visibleWindowCount = \(visibleWindowCount, privacy: .public), isLibraryWindowOpen = \(libraryWindowOpen, privacy: .public), appReopenCausedLibraryWindowOpen = \(self.appReopenCausedLibraryWindowOpen, privacy: .public))")
+    }
+
+    /// Performs a block that may or may not update the list of visible windows, preventing the main library window from being re-opened in case it's not needed.
+    /// This is used when handling the opening of files/links so that the library window is not brought to the foreground unnecessarily.
+    private func updatingWindows(perform block: () -> Void) {
+        let visibleWindowCountBeforeUpdates = NSApplication.shared.windows.filter(\.isVisible).count
+
+        block()
+
+        let visibleWindowCountAfterUpdates = NSApplication.shared.windows.filter(\.isVisible).count
+
+        logger.debug("Visible windows before updates: \(visibleWindowCountBeforeUpdates, privacy: .public), after updates: \(visibleWindowCountAfterUpdates, privacy: .public)")
+
+        /// If the update has opened new windows and the library window is visible, then close the library window as it was only shown as a side-effect of performing the updates.
+        if appReopenCausedLibraryWindowOpen, let libraryWindow {
+            logger.debug("Closing library window because it was automatically opened by SwiftUI due to a URL open")
+
+            libraryWindow.close()
+
+            appReopenCausedLibraryWindowOpen = false
+        }
+    }
+
+    private var isLibraryWindowOpen: Bool {
+        NSApplication.shared.windows.contains(where: { $0.isVirtualBuddyLibraryWindow && $0.isVisible })
+    }
+
+    private var libraryWindow: NSWindow? { NSApplication.shared.windows.first(where: { $0.isVirtualBuddyLibraryWindow }) }
+
+}
+
+extension NSWindow {
+    /// At least as of macOS 14.4, a SwiftUI window's `identifier` matches the `id` that's set in SwiftUI.
+    var isVirtualBuddyLibraryWindow: Bool { identifier?.rawValue == .vb_libraryWindowID }
 }

--- a/VirtualCore/Source/Definitions/Logging.swift
+++ b/VirtualCore/Source/Definitions/Logging.swift
@@ -12,7 +12,7 @@ extension Error {
     var log: String { String(describing: self) }
 }
 
-extension Logger {
+public extension Logger {
     init<T>(for type: T.Type) {
         self.init(subsystem: VirtualCoreConstants.subsystemName, category: String(describing: type))
     }

--- a/VirtualUI/Source/Library/LibraryView.swift
+++ b/VirtualUI/Source/Library/LibraryView.swift
@@ -8,6 +8,10 @@
 import SwiftUI
 import VirtualCore
 
+public extension String {
+    static let vb_libraryWindowID = "library"
+}
+
 public struct LibraryView: View {
     @EnvironmentObject private var library: VMLibraryController
     @EnvironmentObject private var sessionManager: VirtualMachineSessionUIManager
@@ -18,20 +22,6 @@ public struct LibraryView: View {
         libraryContents
             .frame(minWidth: 600, maxWidth: .infinity, minHeight: 600, maxHeight: .infinity)
             .toolbar(content: { toolbarContents })
-            .onOpenURL { url in
-                guard let values = try? url.resourceValues(forKeys: [.contentTypeKey]) else { return }
-                guard values.contentType == .virtualBuddyVM else { return }
-
-                if let loadedVM = library.virtualMachines.first(where: { $0.bundleURL.path == url.path }) {
-                    launch(loadedVM)
-                } else {
-                    guard let vm = try? VBVirtualMachine(bundleURL: url) else {
-                        return
-                    }
-
-                    launch(vm)
-                }
-            }
     }
 
     private var gridSpacing: CGFloat { 16 }
@@ -67,7 +57,7 @@ public struct LibraryView: View {
                 .foregroundColor(.secondary)
 
             Button("Create Your First VM") {
-                launchInstallWizard()
+                sessionManager.launchInstallWizard(library: library)
             }
             .controlSize(.large)
             .keyboardShortcut(.defaultAction)
@@ -82,7 +72,7 @@ public struct LibraryView: View {
             LazyVGrid(columns: gridColumns, spacing: gridSpacing) {
                 ForEach(vms) { vm in
                     Button(vm.name) {
-                        launch(vm)
+                        sessionManager.launch(vm, library: library)
                     }
                     .buttonStyle(VirtualMachineButtonStyle(vm: vm))
                     .environmentObject(library)
@@ -97,54 +87,11 @@ public struct LibraryView: View {
     private var toolbarContents: some ToolbarContent {
         ToolbarItemGroup(placement: .primaryAction) {
             Button {
-                launchInstallWizard()
+                sessionManager.launchInstallWizard(library: library)
             } label: {
                 Image(systemName: "plus")
             }
             .help("Install new VM")
-        }
-    }
-    
-    @Environment(\.openCocoaWindow) private var openWindow
-    
-    private func launch(_ vm: VBVirtualMachine) {
-        guard !vm.needsInstall else {
-            recoverInstallation(for: vm)
-            return
-        }
-
-        openWindow(id: vm.id) {
-            VirtualMachineSessionView(controller: VMController(with: vm), ui: VirtualMachineSessionUI(with: vm))
-                .environmentObject(library)
-                .environmentObject(sessionManager)
-        }
-    }
-
-    private func recoverInstallation(for vm: VBVirtualMachine) {
-        let alert = NSAlert()
-        alert.messageText = "Finish Installation"
-        alert.informativeText = "In order to start this virtual machine, its operating system needs to be installed. Would you like to install it now?"
-        alert.addButton(withTitle: "Install")
-        let deleteButton = alert.addButton(withTitle: "Delete")
-        deleteButton.hasDestructiveAction = true
-        alert.addButton(withTitle: "Cancel")
-
-        let choice = alert.runModal()
-
-        switch choice {
-        case .alertFirstButtonReturn:
-            launchInstallWizard(restoring: vm)
-        case .alertSecondButtonReturn:
-            library.performMoveToTrash(for: vm)
-        default:
-            break
-        }
-    }
-
-    private func launchInstallWizard(restoring restoreVM: VBVirtualMachine? = nil) {
-        openWindow {
-            VMInstallationWizard(restoring: restoreVM)
-                .environmentObject(library)
         }
     }
     

--- a/VirtualUI/Source/Session/VirtualMachineSessionUI.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionUI.swift
@@ -1,22 +1,7 @@
-//
-//  VirtualMachineSessionUI.swift
-//  VirtualUI
-//
-//  Created by Guilherme Rambo on 09/03/23.
-//
-
 import SwiftUI
 import VirtualCore
 import Combine
 import AVFoundation
-
-public final class VirtualMachineSessionUIManager: ObservableObject {
-    public let focusedSessionChanged = PassthroughSubject<VirtualMachineSessionUI?, Never>()
-
-    public static let shared = VirtualMachineSessionUIManager()
-
-    private init() { }
-}
 
 public final class VirtualMachineSessionUI: ObservableObject {
 

--- a/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+import VirtualCore
+import Combine
+import OSLog
+
+public final class VirtualMachineSessionUIManager: ObservableObject {
+    private let logger = Logger(for: VirtualMachineSessionUIManager.self)
+    
+    public let focusedSessionChanged = PassthroughSubject<VirtualMachineSessionUI?, Never>()
+
+    public static let shared = VirtualMachineSessionUIManager()
+
+    private let openWindow = OpenCocoaWindowAction.default
+
+    private init() { }
+
+    @MainActor
+    public func launch(_ vm: VBVirtualMachine, library: VMLibraryController) {
+        guard !vm.needsInstall else {
+            recoverInstallation(for: vm, library: library)
+            return
+        }
+
+        openWindow(id: vm.id) {
+            VirtualMachineSessionView(controller: VMController(with: vm), ui: VirtualMachineSessionUI(with: vm))
+                .environmentObject(library)
+                .environmentObject(self)
+        }
+    }
+
+    @MainActor
+    public func recoverInstallation(for vm: VBVirtualMachine, library: VMLibraryController) {
+        let alert = NSAlert()
+        alert.messageText = "Finish Installation"
+        alert.informativeText = "In order to start this virtual machine, its operating system needs to be installed. Would you like to install it now?"
+        alert.addButton(withTitle: "Install")
+        let deleteButton = alert.addButton(withTitle: "Delete")
+        deleteButton.hasDestructiveAction = true
+        alert.addButton(withTitle: "Cancel")
+
+        let choice = alert.runModal()
+
+        switch choice {
+        case .alertFirstButtonReturn:
+            launchInstallWizard(restoring: vm, library: library)
+        case .alertSecondButtonReturn:
+            library.performMoveToTrash(for: vm)
+        default:
+            break
+        }
+    }
+
+    @MainActor
+    public func launchInstallWizard(restoring restoreVM: VBVirtualMachine? = nil, library: VMLibraryController) {
+        openWindow {
+            VMInstallationWizard(restoring: restoreVM)
+                .environmentObject(library)
+        }
+    }
+
+    @MainActor
+    public func openVirtualMachine(at url: URL, library: VMLibraryController) {
+        do {
+            let values = try url.resourceValues(forKeys: [.contentTypeKey])
+
+            guard values.contentType == .virtualBuddyVM else {
+                throw Failure("Invalid file type: \(String(describing: values.contentType))")
+            }
+
+            if let loadedVM = library.virtualMachines.first(where: { $0.bundleURL.path == url.path }) {
+                launch(loadedVM, library: library)
+            } else {
+                let vm = try VBVirtualMachine(bundleURL: url)
+
+                launch(vm, library: library)
+            }
+        } catch {
+            logger.error("Error loading virtual machine from file at \(url.path, privacy: .public): \(error, privacy: .public)")
+        }
+    }
+
+}


### PR DESCRIPTION
In the process of developing save/restore, I noticed that the app didn't behave very well when opening files, as new windows would be spawned for the opened content, but SwiftUI would also re-open the library window every time.

There was also the issue that the opening of files was directly tied to `LibraryView`.

**This PR:**

- Changes the main "Library" window to a `Window` instead of a `WindowGroup` so that there can not be multiple instances of the library window
- Adds a "Library" item to the "Window" menu that opens the Library window
- Moves the entry point for opening files into the app delegate
- To support the above, moves ownership of `settingsContainer`, `updateController`, `library`, and `sessionManager` from `VirtualBuddyApp` into the app delegate (this doesn't really matter as those are currently all singletons)
- Moves the launching of VM session windows, installation wizard, and install recovery into `VirtualMachineSessionUIManager`
- Adds logic to the app delegate that prevents the library window from showing up when opening files or URLs, so that if the library window was closed before, opening files or URLs in VirtualBuddy won't cause it to re-open

Ideally, we would use SwiftUI's `openWindow` for everything, but unfortunately that's not flexible enough for the sorts of things VirtualBuddy does to its VM windows, so for now the app still uses custom `NSWindow`s for those.