### PR TITLE
Fix window memory leak caused by OnWindowKeyChangedModifier

### DIFF
--- a/VirtualBuddy.xcodeproj/project.pbxproj
+++ b/VirtualBuddy.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		F443620A29B7947A00745B43 /* GuestAdditionsDiskImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F443620929B7947A00745B43 /* GuestAdditionsDiskImage.swift */; };
 		F443620C29B79A6800745B43 /* VirtualBuddyGuest.app in Embed Guest App */ = {isa = PBXBuildFile; fileRef = F4C18A4228491B8500335EC7 /* VirtualBuddyGuest.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		F443620F29B7A0C600745B43 /* CreateGuestImage.sh in Resources */ = {isa = PBXBuildFile; fileRef = F443620E29B7A0C600745B43 /* CreateGuestImage.sh */; };
+		F444D1342BB478AD00AB786F /* VBMemoryLeakDebugAssertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F444D1332BB478AD00AB786F /* VBMemoryLeakDebugAssertions.swift */; };
 		F4450CCA2ACB0DB500092618 /* KeyboardDeviceConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4450CC92ACB0DB500092618 /* KeyboardDeviceConfigurationView.swift */; };
 		F4450CCC2ACB0FDE00092618 /* Preview-Linux.vbvm in Resources */ = {isa = PBXBuildFile; fileRef = F4450CCB2ACB0FDE00092618 /* Preview-Linux.vbvm */; };
 		F44C00FB2889CE1600640BF5 /* VBVirtualMachine+Virtualization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44C00FA2889CE1600640BF5 /* VBVirtualMachine+Virtualization.swift */; };
@@ -425,6 +426,7 @@
 		F43B014D2AD86BFA00164CD1 /* DeepLinkHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkHandler.swift; sourceTree = "<group>"; };
 		F443620929B7947A00745B43 /* GuestAdditionsDiskImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestAdditionsDiskImage.swift; sourceTree = "<group>"; };
 		F443620E29B7A0C600745B43 /* CreateGuestImage.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = CreateGuestImage.sh; sourceTree = "<group>"; };
+		F444D1332BB478AD00AB786F /* VBMemoryLeakDebugAssertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VBMemoryLeakDebugAssertions.swift; sourceTree = "<group>"; };
 		F4450CC92ACB0DB500092618 /* KeyboardDeviceConfigurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardDeviceConfigurationView.swift; sourceTree = "<group>"; };
 		F4450CCB2ACB0FDE00092618 /* Preview-Linux.vbvm */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = "Preview-Linux.vbvm"; sourceTree = "<group>"; };
 		F44C00FA2889CE1600640BF5 /* VBVirtualMachine+Virtualization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VBVirtualMachine+Virtualization.swift"; sourceTree = "<group>"; };
@@ -1340,6 +1342,7 @@
 				F4C2374F2888AF67001FF286 /* LogStreamer.swift */,
 				F4C2374C2888A462001FF286 /* VolumeUtils.swift */,
 				F4510A772AE2A16F00E24DD9 /* WeakReference.swift */,
+				F444D1332BB478AD00AB786F /* VBMemoryLeakDebugAssertions.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1947,6 +1950,7 @@
 				F465C3B8284FA252006E9ED4 /* VBDownloader.swift in Sources */,
 				F4A21BF228032FD8001072B8 /* VMLibraryController.swift in Sources */,
 				F49A68E12884917E00A17582 /* ConfigurationModels.swift in Sources */,
+				F444D1342BB478AD00AB786F /* VBMemoryLeakDebugAssertions.swift in Sources */,
 				F4E7DF8B2BB3141F00C459FC /* VZGraphicsDisplay+Screenshot.m in Sources */,
 				F4C237502888AF67001FF286 /* LogStreamer.swift in Sources */,
 				F4F9B41A284CE37C00F21737 /* Logging.swift in Sources */,

--- a/VirtualBuddy.xcodeproj/xcshareddata/xcschemes/VirtualBuddy (Managed).xcscheme
+++ b/VirtualBuddy.xcodeproj/xcshareddata/xcschemes/VirtualBuddy (Managed).xcscheme
@@ -56,6 +56,10 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "-VBDisableMemoryLeakAssertions YES"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-WHDisablePayloadPropagation YES"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/VirtualCore/Source/Utilities/VBMemoryLeakDebugAssertions.swift
+++ b/VirtualCore/Source/Utilities/VBMemoryLeakDebugAssertions.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+public final class VBMemoryLeakDebugAssertions {
+    @inlinable
+    public static func vb_objectShouldBeReleasedSoon(_ object: AnyObject, after interval: TimeInterval = 0.5) {
+        #if DEBUG
+        _vb_objectShouldBeReleasedSoon(object, after: interval)
+        #endif
+    }
+
+    @inlinable
+    public static func vb_objectIsBeingReleased(_ object: AnyObject) {
+        #if DEBUG
+        _vb_objectIsBeingReleased(object)
+        #endif
+    }
+
+    #if DEBUG
+    public static let _disableFlag = "VBDisableMemoryLeakAssertions"
+
+    public static var _vb_debugAssertionsEnabled: Bool { !UserDefaults.standard.bool(forKey: _disableFlag) }
+
+    public static var _releasedObjects = Set<String>()
+
+    @inlinable
+    public static func _objectID(_ object: AnyObject) -> String {
+        String(describing: Unmanaged.passUnretained(object).toOpaque())
+    }
+
+    @inlinable
+    public static func _vb_objectShouldBeReleasedSoon(_ object: AnyObject, after interval: TimeInterval) {
+        guard _vb_debugAssertionsEnabled else { return }
+
+        let id = _objectID(object)
+        let className = String(describing: type(of: object))
+
+        let description: String
+
+        if let window = object as? NSWindow {
+            let title = window.title
+            description = "#\(id) (\(className) - \"\(title)\")"
+        } else {
+            description = "#\(id) (\(className) - \"\(String(describing: object))\")"
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + interval) {
+            assert(_releasedObjects.contains(id), "💦 POSSIBLE LEAK: \(description) was not released after being closed (set \(_disableFlag) defaults flag to disable this)")
+        }
+    }
+
+    @inlinable
+    public static func _vb_objectIsBeingReleased(_ object: AnyObject) {
+        guard _vb_debugAssertionsEnabled else { return }
+
+        _releasedObjects.insert(_objectID(object))
+    }
+    #endif
+}

--- a/VirtualUI/Source/Components/HostingWindowController/HostingWindowController.swift
+++ b/VirtualUI/Source/Components/HostingWindowController/HostingWindowController.swift
@@ -1,13 +1,6 @@
-//
-//  HostingWindowController.swift
-//  StatusBuddy
-//
-//  Created by Guilherme Rambo on 21/12/21.
-//  Copyright © 2021 Guilherme Rambo. All rights reserved.
-//
-
 import Cocoa
 import SwiftUI
+import VirtualCore
 
 let defaultHostingWindowStyleMask: NSWindow.StyleMask = [.titled, .closable, .fullSizeContentView]
 
@@ -151,6 +144,12 @@ fileprivate final class HostingWindow: VBRestorableWindow {
 
     private func closeWithoutConfirmation() {
         super.close()
+
+        VBMemoryLeakDebugAssertions.vb_objectShouldBeReleasedSoon(self)
+    }
+
+    deinit {
+        VBMemoryLeakDebugAssertions.vb_objectIsBeingReleased(self)
     }
 
 }

--- a/VirtualUI/Source/Components/HostingWindowController/WindowEnvironment.swift
+++ b/VirtualUI/Source/Components/HostingWindowController/WindowEnvironment.swift
@@ -235,24 +235,15 @@ private struct OnWindowKeyChangedModifier: ViewModifier {
     @Environment(\.cocoaWindow)
     private var window
 
-    @State private var cancellables = Set<AnyCancellable>()
-
     func body(content: Content) -> some View {
         content
-            .onAppearOnce {
-                guard let window else { return }
-
-                callback(window.isKeyWindow)
-
-                let center = NotificationCenter.default
-
-                center.publisher(for: NSWindow.didBecomeKeyNotification, object: window).sink { _ in
-                    callback(true)
-                }.store(in: &cancellables)
-
-                center.publisher(for: NSWindow.didResignKeyNotification, object: window).sink { _ in
-                    callback(false)
-                }.store(in: &cancellables)
+            .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification, object: window)) { notification in
+                guard notification.object as? NSWindow === window else { return }
+                callback(true)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: NSWindow.didResignKeyNotification, object: window)) { notification in
+                guard notification.object as? NSWindow === window else { return }
+                callback(false)
             }
     }
 


### PR DESCRIPTION
This addresses a leak of VM windows (`HostingWindow`) caused by the way `OnWindowKeyChangedModifier` was implemented.

Also adds a new `VBMemoryLeakDebugAssertions` object that can be used in debug builds to cause an assertion failure if an object that was expected to be released is not, currently being used in `HostingWindow` (see `closeWithoutConfirmation` and `deinit`).