### PR TITLE
Fixed VM rename space bar bug

### DIFF
--- a/VirtualUI/Source/Library/LibraryView.swift
+++ b/VirtualUI/Source/Library/LibraryView.swift
@@ -71,10 +71,12 @@ public struct LibraryView: View {
         ScrollView(.vertical) {
             LazyVGrid(columns: gridColumns, spacing: gridSpacing) {
                 ForEach(vms) { vm in
-                    Button(vm.name) {
+                    Button {
                         sessionManager.launch(vm, library: library)
+                    } label: {
+                        LibraryItemView(vm: vm, name: vm.name)
                     }
-                    .buttonStyle(VirtualMachineButtonStyle(vm: vm))
+                    .buttonStyle(.vbLibraryItem)
                     .environmentObject(library)
                 }
             }


### PR DESCRIPTION
SwiftUI's button styles are annoying.

It looks like the behavior for all built-in button styles on macOS is to trigger the button's action when pressing the space bar if there's a view inside the button that has focus, which is definitely the case in the library view, where the entire library item is part of the button's label, making it impossible to add a space when renaming a VM.

This implements a `PrimitiveButtonStyle` in order to avoid that.