### PR TITLE
Fixed renamed VM restoring previous name

### DIFF
--- a/VirtualCore/Source/Virtualization/VMLibraryController.swift
+++ b/VirtualCore/Source/Virtualization/VMLibraryController.swift
@@ -221,6 +221,8 @@ public extension VMLibraryController {
         let newURL = try urlForRenaming(vm, to: newName)
 
         try fileManager.moveItem(at: vm.bundleURL, to: newURL)
+
+        reload(animated: false)
     }
 
     @discardableResult


### PR DESCRIPTION
This addresses an issue where rapidly renaming the same VM multiple times could cause the name displayed in the library to no longer match the name that's in the filesystem.