### PR TITLE
Use cached mode for block storage device on Linux guest

### DIFF
--- a/VirtualCore/Source/Virtualization/Helpers/LinuxVirtualMachineConfigurationHelper.swift
+++ b/VirtualCore/Source/Virtualization/Helpers/LinuxVirtualMachineConfigurationHelper.swift
@@ -13,7 +13,7 @@ struct LinuxVirtualMachineConfigurationHelper: VirtualMachineConfigurationHelper
     let vm: VBVirtualMachine
     
     func createInstallDevice(installImageURL: URL) throws -> VZStorageDeviceConfiguration {
-        let attachment = try VZDiskImageStorageDeviceAttachment(url: installImageURL, readOnly: true)
+        let attachment = try VZDiskImageStorageDeviceAttachment(url: installImageURL, readOnly: true, cachingMode: .cached, synchronizationMode: .fsync)
         let usbDeviceConfiguration = VZUSBMassStorageDeviceConfiguration(attachment: attachment)
         return usbDeviceConfiguration
     }


### PR DESCRIPTION
As described in the following [UTM issue](https://github.com/utmapp/UTM/issues/4840), Linux guest sometimes crashes randomly with I/O error.

In my own experience, this is quite hard to reproduce deliberately, but often happens when I am doing heavy I/O operations with large amounts of small files, such as OS install, installing development tools from package manager, compiling native programs (which creates a lot of intermediary `.o` files), etc. File system doesn't matter, I've seen this crash on `ext4` and `xfs`. Interestingly, I could not reproduce this using `stress-ng` `iomix`, even when using btrfs with data checksum enabled and flushed the file system several times. These crashes happen on macOS Sonoma all versions (from the early 14.0 up until 14.4.1) and on pretty much all Linux kernel versions across various distros that `Virtualization.framework` can run. I haven't used VirtualBuddy to run Linux on Ventura, so can't comment on that.

This crash will happen on any disk attached to the VM, whether it is the boot drive or not. Also interestingly, I am yet to reproduce such crashes when the disk image resides on a `tmpfs` file system. But on any APFS file system, internal drive or external drive (Samsung T1 USB 3 = no TRIM on macOS), this kind of I/O crash is always bound to happen.

After using a private build with this change for almost 2 weeks, I am yet to experience any I/O errors, and my files are intact. This is an example of one instance where I managed to run the Linux VM with over 1 day uptime in total and with heavy I/O usage (and the laptop was repeatedly put to sleep as I carry this MacBook Pro everywhere I go = I am a public transport user!):

```
🏠 root@fedora 📁 ~  # iostat
Linux 6.7.9-200.fc39.aarch64 (fedora)   02/04/24        _aarch64_       (8 CPU)

avg-cpu:  %user   %nice %system %iowait  %steal   %idle
           0.30    0.00    0.40    0.00    0.00   99.29

Device             tps    kB_read/s    kB_wrtn/s    kB_dscd/s    kB_read    kB_wrtn    kB_dscd
vda               1.62        77.65       143.22      1364.21    7788688   14366311  136844124
vdb               0.00         0.02         0.03        83.63       2332       2720    8388604

🏠 root@fedora 📁 ~  # uname -a
Linux fedora 6.7.9-200.fc39.aarch64 #1 SMP PREEMPT_DYNAMIC Wed Mar  6 20:03:23 UTC 2024 aarch64 GNU/Linux

🏠 root@fedora 📁 ~  # lsb_release -a
LSB Version:    n/a
Distributor ID: Fedora
Description:    Fedora Linux 39 (Thirty Nine)
Release:        39
Codename:       n/a

🏠 root@fedora 📁 ~  # uptime
 12:35:21 up 1 day,  3:52,  1 user,  load average: 0.17, 0.17, 0.07

🏠 root@fedora 📁 ~  # lsblk
NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
vda    252:0    0   64G  0 disk
├─vda1 252:1    0  200M  0 part /boot/efi
└─vda2 252:2    0 63.8G  0 part /var/lib/containers/storage/overlay
                                /
vdb    252:16   0    8G  0 disk [SWAP]
```