### PR TITLE
Strip preview content from release builds

### DIFF
--- a/VirtualBuddy.xcodeproj/project.pbxproj
+++ b/VirtualBuddy.xcodeproj/project.pbxproj
@@ -1675,6 +1675,7 @@
 				F4BE9C6327FF053A00B648F8 /* Resources */,
 				F4A7FB4C2BB5F0B700E4C12A /* Copy Preview Library */,
 				F4A7FB462BB5ED6400E4C12A /* Copy Preview Saved States */,
+				F4A277142BF51C480011B626 /* Strip Preview Content in Release Builds */,
 			);
 			buildRules = (
 			);
@@ -1912,6 +1913,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Ensures VirtualBuddyGuest has a VBGuestBuildID entry in its Info.plist file\n# This entry is used by the app itself when running in a VM to determine when it needs to be updated.\nTEMPLATE=\"<?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?><!DOCTYPE plist PUBLIC \\\"-//Apple//DTD PLIST 1.0//EN\\\" \\\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\\\"><plist version=\\\"1.0\\\"><dict/></plist>\"\nPLISTPATH=\"$DERIVED_FILE_DIR/VBGenerated-Info.plist\"\n\necho $TEMPLATE > \"$PLISTPATH\"\n\n/usr/libexec/PlistBuddy -c \"Add :VBGuestBuildID string xxxxxx\" \"$PLISTPATH\" 2>/dev/null || echo \"\"\n\n/usr/libexec/PlistBuddy -c \"Set :VBGuestBuildID `uuidgen`\" \"$PLISTPATH\"\n";
+		};
+		F4A277142BF51C480011B626 /* Strip Preview Content in Release Builds */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 8;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Strip Preview Content in Release Builds";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"${CONFIGURATION}\" = \"Release_Managed\" ] || [ \"${CONFIGURATION}\" = \"Dev_Release\" ] ]; then\n    PREVIEW_CONTENT_PATH=\"$CODESIGNING_FOLDER_PATH/Resources/PreviewLibrary\"\n    \n    if [ -d \"$PREVIEW_CONTENT_PATH\" ]; then\n        echo \"Stripping VirtualCore preview content from release build at $PREVIEW_CONTENT_PATH\"\n        rm -r \"$PREVIEW_CONTENT_PATH\"\n    fi\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -2746,7 +2766,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_ASSET_PATHS = VirtualCore/Source/Resources/Preview;
+				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = YES;
@@ -2978,7 +2998,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_ASSET_PATHS = VirtualCore/Source/Resources/Preview;
+				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = YES;
@@ -3188,7 +3208,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_ASSET_PATHS = VirtualCore/Source/Resources/Preview;
+				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = YES;
@@ -3452,7 +3472,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_ASSET_PATHS = VirtualCore/Source/Resources/Preview;
+				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = YES;
@@ -3482,7 +3502,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_ASSET_PATHS = VirtualCore/Source/Resources/Preview;
+				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = YES;


### PR DESCRIPTION
Xcode's built-in development assets feature doesn't seem to work in VirtualCore due to the custom "Copy Files" build phases being used to create a preview VM library.