### PR TITLE
Change snapshot name

### DIFF
--- a/VirtualCore/Source/Models/SavedState/VBSavedStateMetadata.swift
+++ b/VirtualCore/Source/Models/SavedState/VBSavedStateMetadata.swift
@@ -41,7 +41,7 @@ public extension VBVirtualMachine {
     }
 
     /// Convenience for ``VMLibraryController/createSavedStatePackage(for:)``.
-    func createSavedStatePackage(in library: VMLibraryController) throws -> VBSavedStatePackage {
-        try library.createSavedStatePackage(for: self)
+    func createSavedStatePackage(in library: VMLibraryController, snapshotName name: String) throws -> VBSavedStatePackage {
+        try library.createSavedStatePackage(for: self, snapshotName: name)
     }
 }

--- a/VirtualCore/Source/Models/SavedState/VBSavedStatePackage.swift
+++ b/VirtualCore/Source/Models/SavedState/VBSavedStatePackage.swift
@@ -31,9 +31,8 @@ public final class VBSavedStatePackage: Identifiable, Hashable, Codable {
     }
 
     /// Creates a new package on disk for the given virtual machine, initializing the saved state package accordingly.
-    public convenience init(creatingPackageInDirectoryAt baseURL: URL, model: VBVirtualMachine) throws {
-        let suffix = DateFormatter.savedStateFileName.string(from: .now)
-        let url = baseURL.appendingPathComponent("Save-\(suffix)", conformingTo: .virtualBuddySavedState)
+    public convenience init(creatingPackageInDirectoryAt baseURL: URL, model: VBVirtualMachine, snapshotName: String) throws {
+        let url = baseURL.appendingPathComponent(snapshotName, conformingTo: .virtualBuddySavedState)
         let createdURL = try url.creatingDirectoryIfNeeded()
 
         try self.init(url: createdURL, metadata: VBSavedStateMetadata(model: model))
@@ -120,15 +119,6 @@ public final class VBSavedStatePackage: Identifiable, Hashable, Codable {
     }
 
     public static func ==(lhs: VBSavedStatePackage, rhs: VBSavedStatePackage) -> Bool { lhs.metadata == rhs.metadata }
-}
-
-private extension DateFormatter {
-    static let savedStateFileName: DateFormatter = {
-        let f = DateFormatter()
-        f.calendar = .init(identifier: .gregorian)
-        f.dateFormat = "yyyy-MM-dd_HH;mm;ss"
-        return f
-    }()
 }
 
 // MARK: - Validation

--- a/VirtualCore/Source/Models/SavedState/VMLibraryController+SavedState.swift
+++ b/VirtualCore/Source/Models/SavedState/VMLibraryController+SavedState.swift
@@ -23,10 +23,10 @@ public extension VMLibraryController {
             .creatingDirectoryIfNeeded()
     }
 
-    func createSavedStatePackage(for model: VBVirtualMachine) throws -> VBSavedStatePackage {
+    func createSavedStatePackage(for model: VBVirtualMachine, snapshotName name: String) throws -> VBSavedStatePackage {
         let baseURL = try model.savedStatesDirectoryURLCreatingIfNeeded(in: self)
 
-        return try VBSavedStatePackage(creatingPackageInDirectoryAt: baseURL, model: model)
+        return try VBSavedStatePackage(creatingPackageInDirectoryAt: baseURL, model: model, snapshotName: name)
     }
 
     func virtualMachine(with uuid: UUID) throws -> VBVirtualMachine {

--- a/VirtualCore/Source/Virtualization/VMController.swift
+++ b/VirtualCore/Source/Virtualization/VMController.swift
@@ -197,14 +197,14 @@ public final class VMController: ObservableObject {
     }
 
     @available(macOS 14.0, *)
-    public func saveState() async throws {
+    public func saveState(snapshotName name: String) async throws {
         try await updatingState {
             let instance = try ensureInstance()
             let vm = try instance.virtualMachine
 
             state = .savingState(vm)
 
-            let package = try await instance.saveState()
+            let package = try await instance.saveState(snapshotName: name)
 
             state = .stateSaveCompleted(vm, package)
 

--- a/VirtualCore/Source/Virtualization/VMInstance.swift
+++ b/VirtualCore/Source/Virtualization/VMInstance.swift
@@ -290,7 +290,7 @@ public final class VMInstance: NSObject, ObservableObject {
 
     @available(macOS 14.0, *)
     @discardableResult
-    func saveState() async throws -> VBSavedStatePackage {
+    func saveState(snapshotName name: String) async throws -> VBSavedStatePackage {
         logger.debug(#function)
 
         let vm = try ensureVM()
@@ -312,7 +312,7 @@ public final class VMInstance: NSObject, ObservableObject {
 
         logger.debug("VM paused, requesting state save")
 
-        let package = try virtualMachineModel.createSavedStatePackage(in: library)
+        let package = try virtualMachineModel.createSavedStatePackage(in: library, snapshotName: name)
 
         logger.debug("VM state package will be written to \(package.url.path)")
 


### PR DESCRIPTION
This pull request introduces a feature that allows users to rename snapshots of virtual machines with meaningful names before saving them. Previously, snapshots were automatically named with a timestamp format such as `Save-2024-07-21_12;17;16`, which made it difficult to identify the purpose or state of the snapshot.

Changes:
• Implemented a basic UI with a text field that prompts users to enter a custom name for the snapshot before saving.
• The custom name can be descriptive, such as `Clean system` or `VPN issue with DNS`, providing better context for the snapshot.

Benefits:
• Enhanced usability by allowing users to assign meaningful names to snapshots.
• Improved organization and management of snapshots, making it easier to identify and retrieve specific snapshots based on their names.

Additional Notes:
• If no custom name is provided, the system will default to the timestamp format as before.
• This feature aims to improve user experience and streamline the workflow for managing virtual machine snapshots.

![SCR-20240720-brrs](https://github.com/user-attachments/assets/cc35ecb4-81f7-4708-ae35-319839d33242)

