### PR TITLE
Add macOS 14.6 RC

### DIFF
--- a/data/ipsws_v1.json
+++ b/data/ipsws_v1.json
@@ -97,6 +97,14 @@
     },
     {
       "group": "sonoma",
+      "name": "macOS 14.6 RC",
+      "build": "23G80",
+      "url": "https://updates.cdn-apple.com/2024SummerFCS/fullrestores/052-69922/F5DA2B64-25EB-4370-9E89-FA5689859796/UniversalMac_14.6_23G80_Restore.ipsw",
+      "channel": "devbeta",
+      "needsCookie": false
+    },
+    {
+      "group": "sonoma",
       "name": "macOS 14.6 Developer Beta 4",
       "build": "23G5075b",
       "url": "https://updates.cdn-apple.com/2024SpringSeed/fullrestores/062-37092/7D35E462-CD30-4B65-A1D6-D2AF0DA9AED8/UniversalMac_14.6_23G5075b_Restore.ipsw",


### PR DESCRIPTION
~@insidegui macOS 15 beta 4 is out. It has the same build number as the public beta, but a different link. Let me know how you'd like to handle that.~

Nevermind. Pub beta is 24A5289h and beta 4 is 24A5298h. Reading is hard. Opened https://github.com/insidegui/VirtualBuddy/pull/378.