### PR TITLE
Add DFU boot mode option for Mac VMs

### DIFF
--- a/VirtualBuddy.xcodeproj/project.pbxproj
+++ b/VirtualBuddy.xcodeproj/project.pbxproj
@@ -223,6 +223,7 @@
 		F4E7DF952BB336F600C459FC /* VBSavedStatePackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E7DF942BB336F600C459FC /* VBSavedStatePackage.swift */; };
 		F4E7DF972BB33E1700C459FC /* VMLibraryController+SavedState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E7DF962BB33E1700C459FC /* VMLibraryController+SavedState.swift */; };
 		F4E7DFCF2BB3587D00C459FC /* VirtualMachineSessionUIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E7DFCE2BB3587D00C459FC /* VirtualMachineSessionUIManager.swift */; };
+		F4ECC6D52C63BFD5001DAC1D /* NumberDisplayMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4ECC6D42C63BFD5001DAC1D /* NumberDisplayMode.swift */; };
 		F4F5A36029B6324A00F5A12E /* SoftwareVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F5A35F29B6324A00F5A12E /* SoftwareVersion.swift */; };
 		F4F9B416284CE0F900F21737 /* VBSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F9B415284CE0F900F21737 /* VBSettings.swift */; };
 		F4F9B418284CE12000F21737 /* VBSettingsContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F9B417284CE12000F21737 /* VBSettingsContainer.swift */; };
@@ -609,6 +610,7 @@
 		F4E7DF942BB336F600C459FC /* VBSavedStatePackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VBSavedStatePackage.swift; sourceTree = "<group>"; };
 		F4E7DF962BB33E1700C459FC /* VMLibraryController+SavedState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VMLibraryController+SavedState.swift"; sourceTree = "<group>"; };
 		F4E7DFCE2BB3587D00C459FC /* VirtualMachineSessionUIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualMachineSessionUIManager.swift; sourceTree = "<group>"; };
+		F4ECC6D42C63BFD5001DAC1D /* NumberDisplayMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberDisplayMode.swift; sourceTree = "<group>"; };
 		F4F5A35F29B6324A00F5A12E /* SoftwareVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoftwareVersion.swift; sourceTree = "<group>"; };
 		F4F9B415284CE0F900F21737 /* VBSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VBSettings.swift; sourceTree = "<group>"; };
 		F4F9B417284CE12000F21737 /* VBSettingsContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VBSettingsContainer.swift; sourceTree = "<group>"; };
@@ -887,6 +889,7 @@
 			isa = PBXGroup;
 			children = (
 				F42C01572888FC0C00EB15CD /* SwiftUIVMView.swift */,
+				F4ECC6D42C63BFD5001DAC1D /* NumberDisplayMode.swift */,
 				F4694F572A30B9E500F5DFE1 /* VMScreenshotter.swift */,
 				F428622C2AE8726D0052F029 /* VirtualMachineControls.swift */,
 				F4FC98382BB386A000E511C9 /* ContinuousProgressIndicator.swift */,
@@ -2044,6 +2047,7 @@
 				F422587C2885E1CE009420AE /* NetworkConfigurationView.swift in Sources */,
 				F41369A329917FA0002CE8D3 /* ScreenChangeModifier.swift in Sources */,
 				F48E0D1F288882BD0080DDFA /* VMInstallationViewModel.swift in Sources */,
+				F4ECC6D52C63BFD5001DAC1D /* NumberDisplayMode.swift in Sources */,
 				F42258702885D537009420AE /* EphemeralTextField.swift in Sources */,
 				F49AA2C329BA22A5009625F7 /* VBRestorableWindow.swift in Sources */,
 				F422587A2885E17D009420AE /* ConfigurationSection.swift in Sources */,

--- a/VirtualCore/Source/Headers/VirtualizationPrivate.h
+++ b/VirtualCore/Source/Headers/VirtualizationPrivate.h
@@ -47,11 +47,9 @@ __attribute__((weak_import))
 
 @end
 
-@interface VZVirtualMachineStartOptions (Private)
+@interface VZMacOSVirtualMachineStartOptions (VZPrivate)
 
-@property (assign) BOOL _forceDFU;
-@property (assign) BOOL _stopInIBootStage1;
-@property (assign) BOOL _stopInIBootStage2;
+@property (assign, setter=_setForceDFU:) BOOL _forceDFU;
 
 @end
 

--- a/VirtualCore/Source/Virtualization/VMInstance.swift
+++ b/VirtualCore/Source/Virtualization/VMInstance.swift
@@ -249,9 +249,7 @@ public final class VMInstance: NSObject, ObservableObject {
     private var startOptions: VZVirtualMachineStartOptions {
         switch virtualMachineModel.configuration.systemType {
         case .mac:
-            let opts = VZMacOSVirtualMachineStartOptions()
-            opts.startUpFromMacOSRecovery = options.bootInRecoveryMode
-            return opts
+            return VZMacOSVirtualMachineStartOptions(options: options)
         case .linux:
             return VZVirtualMachineStartOptions()
         }
@@ -451,5 +449,21 @@ private extension VBVirtualMachine {
             .deletingPathExtension()
             .lastPathComponent
         return cleanID.removingPercentEncoding ?? cleanID
+    }
+}
+
+extension VZMacOSVirtualMachineStartOptions {
+    convenience init(options: VMSessionOptions) {
+        self.init()
+
+        startUpFromMacOSRecovery = options.bootInRecoveryMode
+
+        if options.bootInDFUMode,
+           VBMacConfiguration.appBuildAllowsDFUMode,
+           self.responds(to: NSSelectorFromString("_setForceDFU:"))
+        {
+            _forceDFU = true
+            startUpFromMacOSRecovery = false
+        }
     }
 }

--- a/VirtualUI/Source/Session/Components/NumberDisplayMode.swift
+++ b/VirtualUI/Source/Session/Components/NumberDisplayMode.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+enum NumberDisplayMode: Int, CaseIterable {
+    case hex
+    case decimal
+
+    var title: String {
+        switch self {
+        case .hex:
+            return "Hex"
+        case .decimal:
+            return "Decimal"
+        }
+    }
+}
+
+extension EnvironmentValues {
+    @Entry var numberDisplayMode: NumberDisplayMode = .decimal
+}
+
+protocol FormattableNumber: CVarArg, FixedWidthInteger {
+    func formatted(mode: NumberDisplayMode) -> String
+}
+
+extension FormattableNumber where Self: SignedInteger {
+    func formatted(mode: NumberDisplayMode) -> String {
+        switch mode {
+        case .hex:
+            return String(format: "0x%02llX", Int64(self))
+        case .decimal:
+            return String(format: "%lld", Int64(self))
+        }
+    }
+}
+
+extension FormattableNumber where Self: UnsignedInteger {
+    func formatted(mode: NumberDisplayMode) -> String {
+        switch mode {
+        case .hex:
+            return String(format: "0x%02llX", UInt64(self))
+        case .decimal:
+            return String(format: "%llu", UInt64(self))
+        }
+    }
+}
+
+extension Int64: FormattableNumber { }
+extension UInt64: FormattableNumber { }
+extension Int32: FormattableNumber { }
+extension UInt32: FormattableNumber { }
+extension Int16: FormattableNumber { }
+extension UInt16: FormattableNumber { }
+extension Int8: FormattableNumber { }
+extension UInt8: FormattableNumber { }

--- a/VirtualUI/Source/Session/Configuration/VMSessionConfigurationView.swift
+++ b/VirtualUI/Source/Session/Configuration/VMSessionConfigurationView.swift
@@ -28,8 +28,14 @@ struct VMSessionConfigurationView: View {
             
             if showRecoveryModeOption {
                 Toggle("Boot in recovery mode", isOn: $controller.options.bootInRecoveryMode)
+                    .disabled(controller.options.bootInDFUMode)
             }
-            
+
+            if showDFUOption {
+                Toggle("Boot in DFU mode", isOn: $controller.options.bootInDFUMode)
+                    .disabled(controller.options.bootInRecoveryMode)
+            }
+
             Toggle("Capture system keyboard shortcuts", isOn: $controller.virtualMachineModel.configuration.captureSystemKeys)
 
             Button("Virtual Machine Settings…") {
@@ -49,14 +55,13 @@ struct VMSessionConfigurationView: View {
 
     private var showRecoveryModeOption: Bool { vm.configuration.systemType == .mac }
 
+    private var showDFUOption: Bool { VBMacConfiguration.appBuildAllowsDFUMode && vm.configuration.systemType == .mac }
+
     private var showSavedStatePicker: Bool { vm.configuration.systemType.supportsStateRestoration }
 }
 
 #if DEBUG
-struct VMSessionConfigurationView_Previews: PreviewProvider {
-    static var previews: some View {
-        VMSessionConfigurationView()
-            .environmentObject(VMController(with: .preview, library: .preview))
-    }
+#Preview {
+    VirtualMachineSessionViewPreview()
 }
 #endif

--- a/VirtualUI/Source/Session/VirtualMachineSessionView.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionView.swift
@@ -281,13 +281,18 @@ extension VMController {
 }
 
 #if DEBUG
-#Preview {
-    VirtualMachineSessionView()
-        .frame(minWidth: 800, maxWidth: .infinity, minHeight: 500, maxHeight: .infinity)
-        .environmentObject(VMLibraryController.preview)
-        .environmentObject(VMController.preview)
-        .environmentObject(VirtualMachineSessionUI.preview)
-        .environmentObject(VirtualMachineSessionUIManager.shared)
+struct VirtualMachineSessionViewPreview: View {
+    var body: some View {
+        VirtualMachineSessionView()
+            .frame(minWidth: 800, maxWidth: .infinity, minHeight: 500, maxHeight: .infinity)
+            .environmentObject(VMLibraryController.preview)
+            .environmentObject(VMController.preview)
+            .environmentObject(VirtualMachineSessionUI.preview)
+            .environmentObject(VirtualMachineSessionUIManager.shared)
+    }
+}
 
+#Preview {
+    VirtualMachineSessionViewPreview()
 }
 #endif

--- a/VirtualUI/Source/Session/VirtualMachineSessionView.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionView.swift
@@ -104,6 +104,8 @@ public struct VirtualMachineSessionView: View {
         SwiftUIVMView(
             controllerState: .constant(.running(vm)),
             captureSystemKeys: controller.virtualMachineModel.configuration.captureSystemKeys,
+            isDFUModeVM: controller.options.bootInDFUMode,
+            vmECID: controller.virtualMachineModel.ECID,
             automaticallyReconfiguresDisplay: .constant(controller.virtualMachineModel.configuration.hardware.displayDevices.count > 0 ? controller.virtualMachineModel.configuration.hardware.displayDevices[0].automaticallyReconfiguresDisplay : false),
             screenshotSubject: screenshotTaken
         )


### PR DESCRIPTION
This implements support for starting up macOS virtual machines in DFU mode.

As this is an advanced feature that can have unintended consequences, it is currently only enabled in debug builds or by setting the `VBShowDFUModeBootOption` defaults flag.

When a VM is started up in DFU mode, the UI displays this information and includes its ECID, which can be used with other tools in order to perform operations with the VM.

<img width="908" alt="VirtualBuddy 2024-08-07 12 24 32" src="https://github.com/user-attachments/assets/a7d8b59c-1a0c-4f2f-8662-985546a04110">
