### PR TITLE
Bug fix: Confirm & stop the VM when the user closes the window if it is neither idle nor stopped.

### DIFF
--- a/VirtualUI/Source/Session/VirtualMachineSessionView.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionView.swift
@@ -192,7 +192,7 @@ public struct VirtualMachineSessionView: View {
         { [weak controller] in
             guard let controller else { return true }
 
-            guard controller.isStarting || controller.isRunning else { return true }
+            if controller.isIdle || controller.isStopped { return true }
 
             let confirmed = await NSAlert.runConfirmationAlert(
                 title: "Stop Virtual Machine?",
@@ -272,12 +272,19 @@ struct VMCircularButtonStyle: ButtonStyle {
 }
 
 extension VMController {
+    var isIdle: Bool {
+        return state == .idle
+    }
+    var isStarting: Bool {
+        guard case .starting = state else { return false }
+        return true
+    }
     var isRunning: Bool {
         guard case .running = state else { return false }
         return true
     }
-    var isStarting: Bool {
-        guard case .starting = state else { return false }
+    var isStopped: Bool {
+        guard case .stopped = state else { return false }
         return true
     }
 }


### PR DESCRIPTION
I noticed that I can close a VM window while it's paused without being prompted whether to stop the VM. But after that, when I try to start the same VM again from the Virtual Buddy window, it's unable to start due to the error "Failed to lock auxiliary storage." That's because the paused VM was not actually stopped. This was clear because exiting and restarting Virtual Buddy does allow me to start the same VM again.

This PR changes the close VM window behavior to present the confirmation alert and (if confirmed) then stop the VM if it is in any state other than `.idle` or `.stopped` when the user attempts to close the window. (If the user interface presented the option to save the VM state while it's paused, we wouldn't need to prompt in the case the user pauses, saves, and then after the save completed, closes the window without unpausing.)