### PR TITLE
Remove macOS 15.1 betas

### DIFF
--- a/data/ipsws_v1.json
+++ b/data/ipsws_v1.json
@@ -65,22 +65,6 @@
   "restoreImages": [
     {
       "group": "sequoia",
-      "name": "macOS 15.1 Developer Beta 2",
-      "build": "24B5024e",
-      "url": "https://updates.cdn-apple.com/2024SummerSeed/fullrestores/062-53173/D1CAA2F8-CBC1-4D27-9F29-9C3BD47CD57C/UniversalMac_15.1_24B5024e_Restore.ipsw",
-      "channel": "devbeta",
-      "needsCookie": false
-    },
-    {
-      "group": "sequoia",
-      "name": "macOS 15.1 Developer Beta 1",
-      "build": "24B5009l",
-      "url": "https://updates.cdn-apple.com/2024SummerSeed/fullrestores/062-47125/381F8D56-0EB1-4EB6-AEF4-04D9BC5D2426/UniversalMac_15.1_24B5009l_Restore.ipsw",
-      "channel": "devbeta",
-      "needsCookie": false
-    },
-    {
-      "group": "sequoia",
       "name": "macOS 15.0 Developer Beta 8",
       "build": "24A5331b",
       "url": "https://updates.cdn-apple.com/2024SummerSeed/fullrestores/062-71949/A67919DD-2AAC-4324-99BF-70765065DD70/UniversalMac_15.0_24A5331b_Restore.ipsw",


### PR DESCRIPTION
Apple is not reliably signing macOS 15.1 betas. Removing to avoid user confusion.

Closes #405.