### PR TITLE
Add macOS 15.1 (24B2083), change 24B83 from beta to regular

### DIFF
--- a/data/ipsws_v1.json
+++ b/data/ipsws_v1.json
@@ -63,12 +63,20 @@
     }
   ],
   "restoreImages": [
+        {
+            "group": "sequoia",
+            "name": "macOS 15.1 (24B2083)",
+            "build": "24B2083",
+            "url": "https://updates.cdn-apple.com/2024FallFCS/fullrestores/072-12302/3786987A-AD94-4BFB-81B8-56D3841CA81B/UniversalMac_15.1_24B2083_Restore.ipsw",
+            "channel": "regular",
+            "needsCookie": false
+        },
     {
       "group": "sequoia",
-      "name": "macOS 15.1 RC 2",
+      "name": "macOS 15.1",
       "build": "24B83",
       "url": "https://updates.cdn-apple.com/2024FallFCS/fullrestores/072-12340/78D28AC4-CCFC-45D2-BD27-1E5D915E43F9/UniversalMac_15.1_24B83_Restore.ipsw",
-      "channel": "devbeta",
+      "channel": "regular",
       "needsCookie": false
     },
     {


### PR DESCRIPTION
Apple released a new build yesterday that seems to be mostly for the new M4 Macs, but it is a universal build and I have verified that it's signed for virtual machines, so I'm making it available.

Also changed 15.1 (24B83) to regular channel.