### PR TITLE
Clone storage devices when saving VM state (#76)

### DIFF
--- a/VirtualBuddy.xcodeproj/project.pbxproj
+++ b/VirtualBuddy.xcodeproj/project.pbxproj
@@ -212,6 +212,9 @@
 		F4D305B029B900860006E748 /* SystemNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D305AF29B900860006E748 /* SystemNotification.swift */; };
 		F4D305B229B907A10006E748 /* WHPing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D305B129B907A10006E748 /* WHPing.swift */; };
 		F4D725FE286677B8001818F7 /* VBVirtualMachine+Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D725FD286677B8001818F7 /* VBVirtualMachine+Metadata.swift */; };
+		F4DE1C0B2D6F54E700603527 /* VBSavedStateMetadata+Clone.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DE1C0A2D6F54E000603527 /* VBSavedStateMetadata+Clone.swift */; };
+		F4DE1C0F2D6F603300603527 /* VBSavedStatePackage+VM.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DE1C0E2D6F603300603527 /* VBSavedStatePackage+VM.swift */; };
+		F4DE1C112D6F642E00603527 /* VBStorageDeviceContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DE1C102D6F642E00603527 /* VBStorageDeviceContainer.swift */; };
 		F4E7680A29B64C590075A897 /* GuestTypePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E7680929B64C590075A897 /* GuestTypePicker.swift */; };
 		F4E7680D29B651220075A897 /* VirtualUI.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F4E7680C29B651220075A897 /* VirtualUI.xcassets */; };
 		F4E7680F29B655DD0075A897 /* InstallMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E7680E29B655DD0075A897 /* InstallMethod.swift */; };
@@ -599,6 +602,9 @@
 		F4D305AF29B900860006E748 /* SystemNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemNotification.swift; sourceTree = "<group>"; };
 		F4D305B129B907A10006E748 /* WHPing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WHPing.swift; sourceTree = "<group>"; };
 		F4D725FD286677B8001818F7 /* VBVirtualMachine+Metadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VBVirtualMachine+Metadata.swift"; sourceTree = "<group>"; };
+		F4DE1C0A2D6F54E000603527 /* VBSavedStateMetadata+Clone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VBSavedStateMetadata+Clone.swift"; sourceTree = "<group>"; };
+		F4DE1C0E2D6F603300603527 /* VBSavedStatePackage+VM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VBSavedStatePackage+VM.swift"; sourceTree = "<group>"; };
+		F4DE1C102D6F642E00603527 /* VBStorageDeviceContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VBStorageDeviceContainer.swift; sourceTree = "<group>"; };
 		F4E7680929B64C590075A897 /* GuestTypePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestTypePicker.swift; sourceTree = "<group>"; };
 		F4E7680C29B651220075A897 /* VirtualUI.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = VirtualUI.xcassets; sourceTree = "<group>"; };
 		F4E7680E29B655DD0075A897 /* InstallMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallMethod.swift; sourceTree = "<group>"; };
@@ -1168,6 +1174,7 @@
 				F4E7DF932BB336E000C459FC /* SavedState */,
 				F4A21BF328033102001072B8 /* VBError.swift */,
 				F4BE9C7327FF055100B648F8 /* VBVirtualMachine.swift */,
+				F4DE1C102D6F642E00603527 /* VBStorageDeviceContainer.swift */,
 				F46FFBA72804F07400D61023 /* VBNVRAMVariable.swift */,
 				F4D725FD286677B8001818F7 /* VBVirtualMachine+Metadata.swift */,
 				F4D0F71428667984004D5782 /* VBVirtualMachine+Screenshot.swift */,
@@ -1528,6 +1535,8 @@
 			children = (
 				F485B91A2BB22D2D004B3C2B /* VBSavedStateMetadata.swift */,
 				F4E7DF942BB336F600C459FC /* VBSavedStatePackage.swift */,
+				F4DE1C0A2D6F54E000603527 /* VBSavedStateMetadata+Clone.swift */,
+				F4DE1C0E2D6F603300603527 /* VBSavedStatePackage+VM.swift */,
 				F4E7DF962BB33E1700C459FC /* VMLibraryController+SavedState.swift */,
 			);
 			path = SavedState;
@@ -2093,6 +2102,7 @@
 				F4E7DF872BB30E1200C459FC /* NSImage+VMScreenshot.swift in Sources */,
 				F48E0D0C2888760D0080DDFA /* VBMacDevice+Storage.swift in Sources */,
 				F465C3AE284F93A5006E9ED4 /* VBAPIClient.swift in Sources */,
+				F4DE1C0B2D6F54E700603527 /* VBSavedStateMetadata+Clone.swift in Sources */,
 				F4D725FE286677B8001818F7 /* VBVirtualMachine+Metadata.swift in Sources */,
 				F4A21BF428033102001072B8 /* VBError.swift in Sources */,
 				F4D0F71F2867517A004D5782 /* AppUpdateChannel.swift in Sources */,
@@ -2105,6 +2115,7 @@
 				F417255F28861604004FF8A7 /* DecodableDefault.swift in Sources */,
 				F485B91B2BB22D2D004B3C2B /* VBSavedStateMetadata.swift in Sources */,
 				F465C3B8284FA252006E9ED4 /* VBDownloader.swift in Sources */,
+				F4DE1C0F2D6F603300603527 /* VBSavedStatePackage+VM.swift in Sources */,
 				F4A7FB3D2BB5E8A200E4C12A /* VMSavedStatesController.swift in Sources */,
 				F4A21BF228032FD8001072B8 /* VMLibraryController.swift in Sources */,
 				F485B91F2BB2F4AC004B3C2B /* Bundle+Version.swift in Sources */,
@@ -2126,6 +2137,7 @@
 				F4F5A36029B6324A00F5A12E /* SoftwareVersion.swift in Sources */,
 				F4E7DF852BB30D8A00C459FC /* VMScreenshotTimingController.swift in Sources */,
 				F4510A782AE2A16F00E24DD9 /* WeakReference.swift in Sources */,
+				F4DE1C112D6F642E00603527 /* VBStorageDeviceContainer.swift in Sources */,
 				F46FFBAC28059FF600D61023 /* VMInstance.swift in Sources */,
 				F4E7DF952BB336F600C459FC /* VBSavedStatePackage.swift in Sources */,
 				F40A1E9D2C1873CA0033E47D /* VBBuildType.swift in Sources */,
@@ -2424,7 +2436,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2460,7 +2472,7 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2491,7 +2503,7 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -2536,7 +2548,7 @@
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -2720,7 +2732,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2755,7 +2767,7 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2785,7 +2797,7 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -2829,7 +2841,7 @@
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -2988,7 +3000,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -3027,7 +3039,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -3066,7 +3078,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -3104,7 +3116,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -3140,7 +3152,7 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3171,7 +3183,7 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3353,7 +3365,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -3388,7 +3400,7 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3418,7 +3430,7 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3462,7 +3474,7 @@
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3620,7 +3632,7 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3651,7 +3663,7 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3680,7 +3692,7 @@
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3830,7 +3842,7 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3860,7 +3872,7 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -3888,7 +3900,7 @@
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -4094,7 +4106,7 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4124,7 +4136,7 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4152,7 +4164,7 @@
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -4182,7 +4194,7 @@
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_MODULE_VERIFIER = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/VirtualBuddy.xcodeproj/xcshareddata/xcschemes/VirtualBuddy.xcscheme
+++ b/VirtualBuddy.xcodeproj/xcshareddata/xcschemes/VirtualBuddy.xcscheme
@@ -55,6 +55,10 @@
             argument = "-VBAPIEnvironment development"
             isEnabled = "NO">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-VBSimulateNonAPFSVolume YES"
+            isEnabled = "NO">
+         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction

--- a/VirtualCore/Source/Definitions/PreviewSupport.swift
+++ b/VirtualCore/Source/Definitions/PreviewSupport.swift
@@ -48,7 +48,8 @@ public extension VMLibraryController {
 
 public extension VMSavedStatesController {
     static var preview: VMSavedStatesController {
-        VMSavedStatesController(directoryURL: Bundle.virtualCore.requiredPreviewDirectoryURL(named: "\(previewLibraryDirName)/_SavedStates"))
+        fatalError("VMSavedStatesController.preview needs to be reimplemented with new VMSavedStatesController requirements")
+//        VMSavedStatesController(directoryURL: Bundle.virtualCore.requiredPreviewDirectoryURL(named: "\(previewLibraryDirName)/_SavedStates"))
     }
 }
 

--- a/VirtualCore/Source/Models/Configuration/ConfigurationModels+Validation.swift
+++ b/VirtualCore/Source/Models/Configuration/ConfigurationModels+Validation.swift
@@ -21,7 +21,7 @@ public extension VBMacConfiguration {
 
         do {
             let config = try await VMInstance.makeConfiguration(for: tempModel)
-            
+
             try config.validate()
             
             return hostSupportState

--- a/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
+++ b/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
@@ -128,7 +128,10 @@ public struct VBStorageDevice: Identifiable, Hashable, Codable {
     /// The underlying storage for the device, which currently can be either a custom disk image,
     /// or a disk image managed by VirtualBuddy.
     public enum BackingStore: Hashable, Codable {
+        /// Image created and managed by VirtualBuddy.
         case managedImage(VBManagedDiskImage)
+        /// Arbitrary image provided by the user, file must exist on disk at the same location
+        /// if the image is to be used again in the future.
         case customImage(URL)
     }
     
@@ -138,6 +141,9 @@ public struct VBStorageDevice: Identifiable, Hashable, Codable {
     /// Setting to `false` disables the storage device without removing it from the VM.
     @DecodableDefault.True
     public var isEnabled: Bool
+    /// `true` if this storage device represents a clone created for a virtual machine save state.
+    @DecodableDefault.False
+    public var isSavedStateClone: Bool
     /// `true` when the device can't be written to by the VM.
     public var isReadOnly: Bool
     /// `true` when the device represents an external USB mass storage device in the guest OS.
@@ -588,8 +594,8 @@ public extension VBStorageDevice {
 
     static var hostSupportsUSBMassStorage: Bool { true }
 
-    func diskImageExists(for vm: VBVirtualMachine) -> Bool {
-        let url = vm.diskImageURL(for: self)
+    func diskImageExists(for container: VBStorageDeviceContainer) -> Bool {
+        let url = container.diskImageURL(for: self)
         return FileManager.default.fileExists(atPath: url.path)
     }
 }

--- a/VirtualCore/Source/Models/SavedState/VBSavedStateMetadata+Clone.swift
+++ b/VirtualCore/Source/Models/SavedState/VBSavedStateMetadata+Clone.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+extension VBSavedStateMetadata {
+    static func createStorageDeviceClones(packageURL: URL, model: VBVirtualMachine) async throws -> [VBStorageDevice] {
+        let inputDevices = model.configuration.hardware.storageDevices
+        var outputDevices = [VBStorageDevice]()
+
+        for var device in inputDevices {
+            guard case .managedImage = device.backing else {
+                /// Custom images are arbirary, may be anywhere on disk or external storage.
+                /// Such images are managed by the user, not the app, and thus are not cloned when saving state.
+                outputDevices.append(device)
+                continue
+            }
+
+            let inputURL: URL = model.diskImageURL(for: device)
+            let cloneURL: URL = packageURL.appending(path: inputURL.lastPathComponent)
+
+            try FileManager.default.copyItem(at: inputURL, to: cloneURL)
+
+            device.isSavedStateClone = true
+
+            outputDevices.append(device)
+        }
+
+        return outputDevices
+    }
+
+    mutating func createStorageDeviceClones(packageURL: URL, model: VBVirtualMachine) async throws {
+        storageDevices = try await Self.createStorageDeviceClones(packageURL: packageURL, model: model)
+    }
+}

--- a/VirtualCore/Source/Models/SavedState/VBSavedStateMetadata.swift
+++ b/VirtualCore/Source/Models/SavedState/VBSavedStateMetadata.swift
@@ -7,6 +7,22 @@ public struct VBSavedStateMetadata: Identifiable, Hashable, Codable {
     public var appVersion: SoftwareVersion
     public var appBuild: Int
     public var hostECID: UInt64?
+
+    /// Copy of ``VBMacDevice/storageDevices`` as those existed at the time the snapshot was taken.
+    /// The ``VBStorageDevice/isSavedStateClone`` property is set to `true` once the state has been saved.
+    /// Only managed disk images are cloned alongside saved states, custom user-provided images are referenced from their original locations.
+    @DecodableDefault.EmptyList
+    public var storageDevices: [VBStorageDevice]
+
+    init(id: UUID, vmUUID: UUID, date: Date, appVersion: SoftwareVersion, appBuild: Int, hostECID: UInt64? = nil, storageDevices: [VBStorageDevice]) {
+        self.id = id
+        self.vmUUID = vmUUID
+        self.date = date
+        self.appVersion = appVersion
+        self.appBuild = appBuild
+        self.hostECID = hostECID
+        self.storageDevices = storageDevices
+    }
 }
 
 // MARK: - Saved State Metadata Creation
@@ -23,7 +39,8 @@ public extension VBSavedStateMetadata {
             date: .now,
             appVersion: Bundle.main.vbVersion,
             appBuild: Bundle.main.vbBuild,
-            hostECID: ecid
+            hostECID: ecid,
+            storageDevices: model.configuration.hardware.storageDevices // will be modified once package is saved
         )
     }
 }

--- a/VirtualCore/Source/Models/SavedState/VBSavedStatePackage+VM.swift
+++ b/VirtualCore/Source/Models/SavedState/VBSavedStatePackage+VM.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+extension VBSavedStatePackage: VBStorageDeviceContainer {
+    public var bundleURL: URL { url }
+    public var storageDevices: [VBStorageDevice] { metadata.storageDevices }
+}

--- a/VirtualCore/Source/Models/SavedState/VMLibraryController+SavedState.swift
+++ b/VirtualCore/Source/Models/SavedState/VMLibraryController+SavedState.swift
@@ -41,8 +41,8 @@ public extension VMLibraryController {
     }
 
     func virtualMachine(forSavedStatePackageURL url: URL) throws -> VBVirtualMachine {
-        let package = try VBSavedStatePackage(url: url)
-        let model = try virtualMachine(forSavedStateMetadata: package.metadata)
+        let metadata = try VBSavedStateMetadata(packageAt: url)
+        let model = try virtualMachine(forSavedStateMetadata: metadata)
         return model
     }
 

--- a/VirtualCore/Source/Models/VBStorageDeviceContainer.swift
+++ b/VirtualCore/Source/Models/VBStorageDeviceContainer.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Adopted by ``VMVirtualMachine`` and ``VBSavedStatePackage``
+/// in order to help resolve storage devices when bootstrapping a VM.
+public protocol VBStorageDeviceContainer {
+    var bundleURL: URL { get }
+    var storageDevices: [VBStorageDevice] { get }
+    var bootDevice: VBStorageDevice { get throws }
+    var bootDiskImage: VBManagedDiskImage { get throws }
+    var allowDiskImageCreation: Bool { get }
+    func diskImageURL(for image: VBManagedDiskImage) -> URL
+    func diskImageURL(for device: VBStorageDevice) -> URL
+}
+
+// MARK: - Default Implementations
+
+/// These default implementations take care of resolving disk images for both ``VBVirtualMachine`` and ``VBSavedStatePackage``.
+/// Which one is used will be determine in `VirtualMachineConfigurationHelper` when bootstrapping the VM.
+public extension VBStorageDeviceContainer {
+    var allowDiskImageCreation: Bool { false }
+
+    var bootDevice: VBStorageDevice {
+        get throws {
+            guard let device = storageDevices.first(where: { $0.isBootVolume }) else {
+                throw Failure("The virtual machine lacks a bootable storage device.")
+            }
+
+            return device
+        }
+    }
+
+    var bootDiskImage: VBManagedDiskImage {
+        get throws {
+            let device = try bootDevice
+
+            guard case .managedImage(let image) = device.backing else {
+                throw Failure("The boot device must use a disk image managed by VirtualBuddy")
+            }
+
+            return image
+        }
+    }
+
+    func diskImageURL(for image: VBManagedDiskImage) -> URL {
+        bundleURL
+            .appendingPathComponent(image.filename)
+            .appendingPathExtension(image.format.fileExtension)
+    }
+
+    func diskImageURL(for device: VBStorageDevice) -> URL {
+        switch device.backing {
+        case .managedImage(let image):
+            return diskImageURL(for: image)
+        case .customImage(let customURL):
+            return customURL
+        }
+    }
+}

--- a/VirtualCore/Source/Utilities/VolumeUtils.swift
+++ b/VirtualCore/Source/Utilities/VolumeUtils.swift
@@ -22,11 +22,20 @@ public extension VBSettingsContainer {
 
 }
 
+public extension VMLibraryController {
+    /// Whether this library is stored in an APFS volume.
+    var isInAPFSVolume: Bool { libraryURL.hasAPFSIdentifier }
+}
+
 public extension URL {
 
     /// Checks if the item at the URL contains an APFS content identifier, as a way to check for
     /// whether the containing volume is an APFS volume.
     var hasAPFSIdentifier: Bool {
+        #if DEBUG
+        guard !UserDefaults.standard.bool(forKey: "VBSimulateNonAPFSVolume") else { return false }
+        #endif
+
         guard let values = try? resourceValues(forKeys: [.fileContentIdentifierKey]),
               values.fileContentIdentifier != nil
         else {

--- a/VirtualCore/Source/Virtualization/Helpers/LinuxVirtualMachineConfigurationHelper.swift
+++ b/VirtualCore/Source/Virtualization/Helpers/LinuxVirtualMachineConfigurationHelper.swift
@@ -11,7 +11,13 @@ import Virtualization
 @available(macOS 13.0, *)
 struct LinuxVirtualMachineConfigurationHelper: VirtualMachineConfigurationHelper {
     let vm: VBVirtualMachine
-    
+    let savedState: VBSavedStatePackage?
+
+    init(vm: VBVirtualMachine) {
+        self.vm = vm
+        self.savedState = nil
+    }
+
     func createInstallDevice(installImageURL: URL) throws -> VZStorageDeviceConfiguration {
         let attachment = try VZDiskImageStorageDeviceAttachment(url: installImageURL, readOnly: true, cachingMode: .cached, synchronizationMode: .fsync)
         let usbDeviceConfiguration = VZUSBMassStorageDeviceConfiguration(attachment: attachment)

--- a/VirtualCore/Source/Virtualization/Helpers/MacOSVirtualMachineConfigurationHelper.swift
+++ b/VirtualCore/Source/Virtualization/Helpers/MacOSVirtualMachineConfigurationHelper.swift
@@ -10,7 +10,8 @@ import Virtualization
 
 struct MacOSVirtualMachineConfigurationHelper: VirtualMachineConfigurationHelper {
     let vm: VBVirtualMachine
-    
+    let savedState: VBSavedStatePackage?
+
     func createInstallDevice(installImageURL: URL) throws -> VZStorageDeviceConfiguration {
         fatalError()
     }
@@ -28,7 +29,7 @@ struct MacOSVirtualMachineConfigurationHelper: VirtualMachineConfigurationHelper
     }
 
     func createAdditionalBlockDevices() async throws -> [VZVirtioBlockDeviceConfiguration] {
-        var devices = try vm.additionalBlockDevices
+        var devices = try storageDeviceContainer.additionalBlockDevices(guestType: vm.configuration.systemType)
 
         if vm.configuration.guestAdditionsEnabled, let disk = try? VZVirtioBlockDeviceConfiguration.guestAdditionsDisk {
             devices.append(disk)

--- a/VirtualCore/Source/Virtualization/Helpers/VirtualMachineConfigurationHelper.swift
+++ b/VirtualCore/Source/Virtualization/Helpers/VirtualMachineConfigurationHelper.swift
@@ -10,6 +10,7 @@ import Virtualization
 
 protocol VirtualMachineConfigurationHelper {
     var vm: VBVirtualMachine { get }
+    var savedState: VBSavedStatePackage? { get }
     func createInstallDevice(installImageURL: URL) throws -> VZStorageDeviceConfiguration
     func createBootLoader() throws -> VZBootLoader
     func createBootBlockDevice() async throws -> VZVirtioBlockDeviceConfiguration
@@ -36,17 +37,23 @@ func createVZDiskImageStorageDeviceAttachment(url: URL, readOnly: Bool, guestTyp
 
 extension VirtualMachineConfigurationHelper {
 
+    var storageDeviceContainer: VBStorageDeviceContainer { savedState ?? vm }
+
     func createBootBlockDevice() async throws -> VZVirtioBlockDeviceConfiguration {
         do {
-            let bootDevice = try vm.bootDevice
-            let bootDiskImage = try vm.bootDiskImage
+            let bootDevice = try storageDeviceContainer.bootDevice
+            let bootDiskImage = try storageDeviceContainer.bootDiskImage
             
-            if !bootDevice.diskImageExists(for: vm) {
+            if !bootDevice.diskImageExists(for: storageDeviceContainer) {
+                guard storageDeviceContainer.allowDiskImageCreation else {
+                    throw Failure("Boot disk image does not exist.")
+                }
+
                 let settings = DiskImageGenerator.ImageSettings(for: bootDiskImage, in: vm)
                 try await DiskImageGenerator.generateImage(with: settings)
             }
 
-            let bootURL = vm.diskImageURL(for: bootDiskImage)
+            let bootURL = storageDeviceContainer.diskImageURL(for: bootDiskImage)
             let diskImageAttachment = try createVZDiskImageStorageDeviceAttachment(url: bootURL, readOnly: false, guestType: vm.configuration.systemType)
 
             let disk = VZVirtioBlockDeviceConfiguration(attachment: diskImageAttachment)
@@ -58,7 +65,7 @@ extension VirtualMachineConfigurationHelper {
     }
     
     func createAdditionalBlockDevices() async throws -> [VZVirtioBlockDeviceConfiguration] {
-        try vm.additionalBlockDevices
+        try storageDeviceContainer.additionalBlockDevices(guestType: vm.configuration.systemType)
     }
 
     func createKeyboardConfiguration() -> VZKeyboardConfiguration {
@@ -75,22 +82,20 @@ extension VirtualMachineConfigurationHelper {
 
 }
 
-extension VBVirtualMachine {
-    var additionalBlockDevices: [VZVirtioBlockDeviceConfiguration] {
-        get throws {
-            var output = [VZVirtioBlockDeviceConfiguration]()
+extension VBStorageDeviceContainer {
+    func additionalBlockDevices(guestType: VBGuestType) throws -> [VZVirtioBlockDeviceConfiguration] {
+        var output = [VZVirtioBlockDeviceConfiguration]()
 
-            for device in configuration.hardware.storageDevices {
-                guard device.isEnabled, !device.isBootVolume else { continue }
+        for device in storageDevices {
+            guard device.isEnabled, !device.isBootVolume else { continue }
 
-                let url = diskImageURL(for: device)
-                let attachment = try createVZDiskImageStorageDeviceAttachment(url: url, readOnly: device.isReadOnly, guestType: configuration.systemType)
+            let url = diskImageURL(for: device)
+            let attachment = try createVZDiskImageStorageDeviceAttachment(url: url, readOnly: device.isReadOnly, guestType: guestType)
 
-                output.append(VZVirtioBlockDeviceConfiguration(attachment: attachment))
-            }
-
-            return output
+            output.append(VZVirtioBlockDeviceConfiguration(attachment: attachment))
         }
+
+        return output
     }
 }
 

--- a/VirtualCore/Source/Virtualization/VMController.swift
+++ b/VirtualCore/Source/Virtualization/VMController.swift
@@ -35,16 +35,16 @@ public struct VMSessionOptions: Hashable, Codable {
     public var autoBoot = false
 
     /// Used when restoring from a previously-saved state.
-    public var stateRestorationPackage: VBSavedStatePackage?
+    public var stateRestorationPackageURL: URL?
 
     public static let `default` = VMSessionOptions()
 
-    public init(bootInRecoveryMode: Bool = false, bootInDFUMode: Bool = false, bootOnInstallDevice: Bool = false, autoBoot: Bool = false, stateRestorationPackage: VBSavedStatePackage? = nil) {
+    public init(bootInRecoveryMode: Bool = false, bootInDFUMode: Bool = false, bootOnInstallDevice: Bool = false, autoBoot: Bool = false, stateRestorationPackageURL: URL? = nil) {
         self.bootInRecoveryMode = bootInRecoveryMode
         self.bootInDFUMode = bootInDFUMode
         self.bootOnInstallDevice = bootOnInstallDevice
         self.autoBoot = autoBoot
-        self.stateRestorationPackage = stateRestorationPackage
+        self.stateRestorationPackageURL = stateRestorationPackageURL
 
         resolveMutuallyExclusiveOptions()
     }
@@ -161,8 +161,9 @@ public final class VMController: ObservableObject {
             let newInstance = try createInstance()
             self.instance = newInstance
 
-            if #available(macOS 14.0, *), let restorePackage = options.stateRestorationPackage {
-                try await newInstance.restoreState(from: restorePackage) { vm, package in
+            if #available(macOS 14.0, *), let restorePackageURL = options.stateRestorationPackageURL {
+                let package = try VBSavedStatePackage(url: restorePackageURL)
+                try await newInstance.restoreState(from: package) { vm, package in
                     try? await updatingState {
                         state = .restoringState(vm, package)
                     }

--- a/VirtualCore/Source/Virtualization/VMInstance.swift
+++ b/VirtualCore/Source/Virtualization/VMInstance.swift
@@ -92,13 +92,13 @@ public final class VMInstance: NSObject, ObservableObject {
 
     // MARK: Create the Virtual Machine Configuration and instantiate the Virtual Machine
 
-    public static func makeConfiguration(for model: VBVirtualMachine, installImageURL: URL? = nil) async throws -> VZVirtualMachineConfiguration {
+    public static func makeConfiguration(for model: VBVirtualMachine, installImageURL: URL? = nil, savedState: VBSavedStatePackage? = nil) async throws -> VZVirtualMachineConfiguration {
         let helper: VirtualMachineConfigurationHelper
         let platform: VZPlatformConfiguration
         let installDevice: [VZStorageDeviceConfiguration]
         switch model.configuration.systemType {
         case .mac:
-            helper = MacOSVirtualMachineConfigurationHelper(vm: model)
+            helper = MacOSVirtualMachineConfigurationHelper(vm: model, savedState: savedState)
             platform = try await Self.createMacPlatform(for: model, installImageURL: installImageURL)
             installDevice = []
         case .linux:
@@ -138,7 +138,7 @@ public final class VMInstance: NSObject, ObservableObject {
         return c
     }
     
-    private func createVirtualMachine() async throws {
+    private func createVirtualMachine(savedState: VBSavedStatePackage?) async throws {
         logger.debug(#function)
 
         let installImage: URL?
@@ -147,7 +147,7 @@ public final class VMInstance: NSObject, ObservableObject {
         } else {
             installImage = nil
         }
-        let config = try await Self.makeConfiguration(for: virtualMachineModel, installImageURL: installImage) // add install iso here for linux (hack)
+        let config = try await Self.makeConfiguration(for: virtualMachineModel, installImageURL: installImage, savedState: savedState) // add install iso here for linux (hack)
 
         await setupWormhole(for: config)
 
@@ -231,8 +231,8 @@ public final class VMInstance: NSObject, ObservableObject {
         #endif
     }
 
-    private func bootstrap() async throws {
-        try await createVirtualMachine()
+    private func bootstrap(savedState: VBSavedStatePackage? = nil) async throws {
+        try await createVirtualMachine(savedState: savedState)
 
         let vm = try ensureVM()
 
@@ -329,6 +329,8 @@ public final class VMInstance: NSObject, ObservableObject {
         package.screenshot = screenshot
 
         do {
+            try await package.createStorageDeviceClones(model: virtualMachineModel)
+
             try await vm.saveMachineStateTo(url: package.dataFileURL)
 
             logger.log("VM state saved to \(package.dataFileURL.path)")
@@ -380,7 +382,7 @@ public final class VMInstance: NSObject, ObservableObject {
         if _virtualMachine == nil {
             logger.debug("Bootstrapping VM for state restoration")
 
-            try await bootstrap()
+            try await bootstrap(savedState: package)
         }
 
         let vm = try ensureVM()

--- a/VirtualCore/Source/Virtualization/VMSavedStatesController.swift
+++ b/VirtualCore/Source/Virtualization/VMSavedStatesController.swift
@@ -12,13 +12,11 @@ public final class VMSavedStatesController: ObservableObject {
     private let filePresenter: DirectoryObserver
     private let updateSignal = PassthroughSubject<URL, Never>()
     private let directoryURL: URL
+    private let virtualMachine: VBVirtualMachine
 
-    public convenience init(library: VMLibraryController, virtualMachine: VBVirtualMachine) {
-        self.init(directoryURL: virtualMachine.savedStatesDirectoryURL(in: library))
-    }
-
-    public init(directoryURL: URL) {
-        self.directoryURL = directoryURL
+    public init(library: VMLibraryController, virtualMachine: VBVirtualMachine) {
+        self.virtualMachine = virtualMachine
+        self.directoryURL = library.savedStateDirectoryURL(for: virtualMachine)
         self.filePresenter = DirectoryObserver(
             presentedItemURL: directoryURL,
             fileExtensions: [VBSavedStatePackage.fileExtension],

--- a/VirtualUI/Source/Session/Components/SavedStatePicker.swift
+++ b/VirtualUI/Source/Session/Components/SavedStatePicker.swift
@@ -4,23 +4,23 @@ import VirtualCore
 struct SavedStatePicker: View {
     @EnvironmentObject private var controller: VMSavedStatesController
 
-    @Binding var selection: VBSavedStatePackage?
+    @Binding var selectedStateURL: URL?
 
     var body: some View {
-        Picker("State", selection: $selection) {
+        Picker("State", selection: $selectedStateURL) {
             if controller.states.isEmpty {
                 Text("No Saved States")
-                    .tag(Optional<VBSavedStatePackage>.none)
+                    .tag(Optional<URL>.none)
             } else {
                 Text("Don’t Restore")
-                    .tag(Optional<VBSavedStatePackage>.none)
+                    .tag(Optional<URL>.none)
 
                 Divider()
             }
 
             ForEach(controller.states) { state in
                 Text(state.url.deletingPathExtension().lastPathComponent)
-                    .tag(Optional<VBSavedStatePackage>.some(state))
+                    .tag(Optional<URL>.some(state.url))
             }
         }
         .disabled(controller.states.isEmpty)
@@ -30,11 +30,11 @@ struct SavedStatePicker: View {
 #if DEBUG
 private struct _Preview: View {
     @StateObject private var controller = VMSavedStatesController.preview
-    @State private var selectedState: VBSavedStatePackage?
+    @State private var selectedStateURL: URL?
 
     var body: some View {
         Form {
-            SavedStatePicker(selection: $selectedState)
+            SavedStatePicker(selectedStateURL: $selectedStateURL)
                 .environmentObject(controller)
         }
         .formStyle(.grouped)

--- a/VirtualUI/Source/Session/Components/VirtualMachineControls.swift
+++ b/VirtualUI/Source/Session/Components/VirtualMachineControls.swift
@@ -80,8 +80,8 @@ struct VirtualMachineControls<Controller: VirtualMachineStateController>: View {
                                 Button("Save") {
                                     isPopoverPresented = false
 
-                                    Task {
-                                        try await controller.saveState(snapshotName: textFieldContent)
+                                    runToolbarAction {
+                                        try await saveState()
                                     }
                                 }
                                 .keyboardShortcut(.defaultAction)
@@ -126,6 +126,15 @@ struct VirtualMachineControls<Controller: VirtualMachineStateController>: View {
 
                 NSAlert(error: error).runModal()
             }
+        }
+    }
+
+    private func saveState() async throws {
+        do {
+            try await controller.saveState(snapshotName: textFieldContent)
+        } catch {
+            guard !(error is CancellationError) else { return }
+            throw error
         }
     }
 }

--- a/VirtualUI/Source/Session/Configuration/VMSessionConfigurationView.swift
+++ b/VirtualUI/Source/Session/Configuration/VMSessionConfigurationView.swift
@@ -18,7 +18,7 @@ struct VMSessionConfigurationView: View {
     var body: some View {
         SelfSizingGroupedForm(minHeight: 100) {
             if showSavedStatePicker {
-                SavedStatePicker(selection: $controller.options.stateRestorationPackage)
+                SavedStatePicker(selectedStateURL: $controller.options.stateRestorationPackageURL)
                     .environmentObject(controller.savedStatesController)
             }
             

--- a/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
@@ -152,9 +152,7 @@ private extension VirtualMachineSessionUIManager {
         do {
             let model = try library.virtualMachine(forSavedStatePackageURL: url)
 
-            let package = try VBSavedStatePackage(url: url)
-
-            let options = VMSessionOptions(stateRestorationPackage: package)
+            let options = VMSessionOptions(stateRestorationPackageURL: url)
 
             launch(model, library: library, options: options)
         } catch {

--- a/VirtualUI/Source/Session/VirtualMachineSessionView.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionView.swift
@@ -239,8 +239,9 @@ struct VMScreenshotBackgroundView: View {
     }
     
     private func updateImage(options: VMSessionOptions) {
-        if let restorePackage = options.stateRestorationPackage,
-           let screenshot = restorePackage.screenshot
+        if let packageURL = options.stateRestorationPackageURL,
+           let package = try? VBSavedStatePackage(url: packageURL),
+           let screenshot = package.screenshot
         {
             image = Image(nsImage: screenshot)
         } else if let screenshot = vm.screenshot {


### PR DESCRIPTION
As noted by @thierryfranzetti in https://github.com/insidegui/VirtualBuddy/discussions/76#discussioncomment-12324263

Storage device clones must be stored alongside saved state in order to successfully restore the VM in the long term.

This also adds a warning when attempting to save state if the VM data is not in an APFS volume, in which case cloning the storage devices is not possible.