### PR TITLE
Enlarge grouped list's button

### DIFF
--- a/VirtualUI/Source/VM Configuration/Components/GroupedList.swift
+++ b/VirtualUI/Source/VM Configuration/Components/GroupedList.swift
@@ -88,6 +88,7 @@ struct GroupedList<Content: View, HeaderAccessory: View, FooterAccessory: View, 
                     }
                 }
                 .labelStyle(.iconOnly)
+                .applyGroupedListCommandButtonStyle()
                 
                 footerAccessory()
             }
@@ -140,5 +141,17 @@ extension GroupedList where HeaderAccessory == EmptyView, FooterAccessory == Emp
         self.emptyOverlay = emptyOverlay
         self.addButton = addButton
         self.removeButton = removeButton
+    }
+}
+
+fileprivate extension View {
+    func applyGroupedListCommandButtonStyle() -> some View {
+        // the .accessoryBarAction looks nicer, but only available on macOS Sonoma
+        // on older version of macOS, use the default style (equivalent to .bordered)
+        if #available(macOS 14.0, *) {
+            return self.buttonStyle(.accessoryBarAction)
+        } else {
+            return self
+        }
     }
 }

--- a/VirtualUI/Source/VM Configuration/Components/GroupedList.swift
+++ b/VirtualUI/Source/VM Configuration/Components/GroupedList.swift
@@ -13,15 +13,15 @@ struct GroupedList<Content: View, HeaderAccessory: View, FooterAccessory: View, 
     var headerAccessory: () -> HeaderAccessory
     var footerAccessory: () -> FooterAccessory
     var emptyOverlay: () -> EmptyOverlay
-    var addButton: (Image) -> AddButton?
-    var removeButton: (Image) -> RemoveButton?
+    var addButton: (Label<Text, Image>) -> AddButton?
+    var removeButton: (Label<Text, Image>) -> RemoveButton?
     
     init(@ViewBuilder _ content: @escaping () -> Content,
          headerAccessory: @escaping () -> HeaderAccessory,
          footerAccessory: @escaping () -> FooterAccessory,
          emptyOverlay: @escaping () -> EmptyOverlay,
-         addButton: @escaping (Image) -> AddButton? = { _ in nil },
-         removeButton: @escaping (Image) -> RemoveButton? = { _ in nil })
+         addButton: @escaping (Label<Text, Image>) -> AddButton? = { _ in nil },
+         removeButton: @escaping (Label<Text, Image>) -> RemoveButton? = { _ in nil })
     {
         self.content = content
         self.headerAccessory = headerAccessory
@@ -71,8 +71,8 @@ struct GroupedList<Content: View, HeaderAccessory: View, FooterAccessory: View, 
             .padding(.horizontal, 2)
     }
     
-    private let addLabel = Image(systemName: "plus")
-    private let removeLabel = Image(systemName: "minus")
+    private let addLabel = Label("Add", systemImage: "plus")
+    private let removeLabel = Label("Remove", systemImage: "minus")
     
     @ViewBuilder
     private var listButtons: some View {
@@ -81,17 +81,13 @@ struct GroupedList<Content: View, HeaderAccessory: View, FooterAccessory: View, 
                 Group {
                     if let addButton = addButton(addLabel) {
                         addButton
-                            .frame(width: 16, height: 16)
-                            .contentShape(Rectangle())
                     }
                     
                     if let removeButton = removeButton(removeLabel) {
                         removeButton
-                            .frame(width: 16, height: 16)
-                            .contentShape(Rectangle())
                     }
                 }
-                .buttonStyle(.borderless)
+                .labelStyle(.iconOnly)
                 
                 footerAccessory()
             }
@@ -135,8 +131,8 @@ extension GroupedList where FooterAccessory == EmptyView, EmptyOverlay == EmptyV
 extension GroupedList where HeaderAccessory == EmptyView, FooterAccessory == EmptyView {
     init(@ViewBuilder _ content: @escaping () -> Content,
          emptyOverlay: @escaping () -> EmptyOverlay,
-         addButton: @escaping (Image) -> AddButton? = { _ in nil },
-         removeButton: @escaping (Image) -> RemoveButton? = { _ in nil })
+         addButton: @escaping (Label<Text, Image>) -> AddButton? = { _ in nil },
+         removeButton: @escaping (Label<Text, Image>) -> RemoveButton? = { _ in nil })
     {
         self.content = content
         self.headerAccessory = { EmptyView() }


### PR DESCRIPTION
This change enlarges grouped list's "+" and "-" button's hit point.

It is unfortunate that SwiftUI button's hit point for borderless buttons follows the size of its label. For such buttons, enlarging the hit point requires us to do `.frame()` on the label (`Image`) itself. However, the `frame()` function returns `some View`, which is impossible to pass around as a function parameter. An alternative approach would be to invoke `frame()` on all users of `GroupedList`, which I think is not ideal. After this patch, it will look like this:

<img width="452" alt="Screenshot 2025-03-26 at 20 47 01" src="https://github.com/user-attachments/assets/85a9a071-7ac6-4043-a619-210cb07f2d6d" />

Another alternative would be to use the new `.accessoryBar` for `.buttonStyle`, which in my opinion looks nicer. However, it is only available on macOS 14 or newer. Here is how it looks like:

<img width="453" alt="Screenshot 2025-03-26 at 21 04 18" src="https://github.com/user-attachments/assets/6263cedc-e97a-4159-a77a-22db564f47dc" />