### PR TITLE
Adopt guest disk image suffixes by build type, calculate size

### DIFF
--- a/VirtualBuddy/Config/AppTarget.xcconfig
+++ b/VirtualBuddy/Config/AppTarget.xcconfig
@@ -5,7 +5,7 @@
 // Entitlement Settings
 
 // Name of the provisioning profile used for all managed builds (debug, beta, release, dev release).
-MANAGED_PROFILE = VirtualBuddy Mid 2024 B
+MANAGED_PROFILE = VirtualBuddy Dev Mid 2025
 
 CODE_SIGN_ENTITLEMENTS[config=Debug][sdk=*][arch=*] = $(ENTITLEMENTS_DIR)/VirtualBuddy.entitlements
 CODE_SIGN_ENTITLEMENTS[config=Release][sdk=*][arch=*] = $(ENTITLEMENTS_DIR)/VirtualBuddy.entitlements

--- a/VirtualCore/Source/GuestSupport/GuestAdditionsDiskImage.swift
+++ b/VirtualCore/Source/GuestSupport/GuestAdditionsDiskImage.swift
@@ -18,25 +18,30 @@ public final class GuestAdditionsDiskImage {
     public static let current = GuestAdditionsDiskImage()
 
     public func installIfNeeded() async throws {
-        logger.debug(#function)
+        do {
+            logger.debug(#function)
 
-        let embeddedDigest = try computeEmbeddedGuestDigest()
+            let embeddedDigest = try computeEmbeddedGuestDigest()
 
-        if let currentlyInstalledGuestImageDigest {
-            logger.debug("Embedded guest app digest: \(embeddedDigest, privacy: .public) / Library guest app digest: \(currentlyInstalledGuestImageDigest, privacy: .public)")
+            if let currentlyInstalledGuestImageDigest {
+                logger.debug("Embedded guest app digest: \(embeddedDigest, privacy: .public) / Library guest app digest: \(currentlyInstalledGuestImageDigest, privacy: .public)")
 
-            guard embeddedDigest != currentlyInstalledGuestImageDigest else {
-                logger.debug("Guest digests match, skipping guest image generation")
-                return
+                guard embeddedDigest != currentlyInstalledGuestImageDigest else {
+                    logger.debug("Guest digests match, skipping guest image generation")
+                    return
+                }
+
+                logger.debug("Guest digests don't match, generating new guest image with embedded guest")
+
+                try await writeGuestImage(with: embeddedDigest)
+            } else {
+                logger.debug("No digest for currently installed image, assuming not installed. Embedded guest app digest: \(embeddedDigest, privacy: .public)")
+
+                try await writeGuestImage(with: embeddedDigest)
             }
-
-            logger.debug("Guest digests don't match, generating new guest image with embedded guest")
-
-            try await writeGuestImage(with: embeddedDigest)
-        } else {
-            logger.debug("No digest for currently installed image, assuming not installed. Embedded guest app digest: \(embeddedDigest, privacy: .public)")
-
-            try await writeGuestImage(with: embeddedDigest)
+        } catch {
+            logger.error("Guest disk image installation failed. \(error, privacy: .public)")
+            throw error
         }
     }
 
@@ -70,7 +75,15 @@ public final class GuestAdditionsDiskImage {
         }
     }
 
-    private var imageName: String { "VirtualBuddyGuest" }
+    private var _imageBaseName: String { "VirtualBuddyGuest" }
+
+    private var imageName: String {
+        if let suffix = VBBuildType.current.guestAdditionsImageSuffix {
+            _imageBaseName + suffix
+        } else {
+            _imageBaseName
+        }
+    }
 
     private var imagesRootURL: URL { URL.defaultVirtualBuddyLibraryURL.appendingPathComponent("_GuestImage") }
 
@@ -142,15 +155,24 @@ public final class GuestAdditionsDiskImage {
 
     private func writeGuestImage(with digest: String) async throws {
         let scriptPath = try generatorScriptURL.path
-        let guestPath = try embeddedGuestAppURL.path
+        let guestURL = try embeddedGuestAppURL
+        let guestPath = guestURL.path
+        let size = computeImageSizeInMB(guestAppURL: guestURL)
+
+        var args: [String] = [
+            scriptPath,
+            guestPath,
+            digest,
+            "\(size)MB"
+        ]
+
+        if let suffix = VBBuildType.current.guestAdditionsImageSuffix {
+            args.append(suffix)
+        }
 
         let p = Process()
         p.executableURL = URL(fileURLWithPath: "/bin/sh")
-        p.arguments = [
-            scriptPath,
-            guestPath,
-            digest
-        ]
+        p.arguments = args
         let outPipe = Pipe()
         let errPipe = Pipe()
         p.standardOutput = outPipe
@@ -174,7 +196,7 @@ public final class GuestAdditionsDiskImage {
         #endif
 
         guard p.terminationStatus == 0 else {
-            if let message = errData.map({ String(decoding: $0, as: UTF8.self) })?.components(separatedBy: .newlines).last {
+            if let message = errData.flatMap({ String(decoding: $0, as: UTF8.self) }) {
                 throw Failure(message)
             } else {
                 throw Failure("Guest additions disk image generator failed with exit code \(p.terminationStatus)")
@@ -202,4 +224,73 @@ extension VZVirtioBlockDeviceConfiguration {
         }
     }
 
+}
+
+// MARK: - Image Size Calculation
+
+private extension GuestAdditionsDiskImage {
+    /// Fallback size in case image size can't be calculated.
+    static let defaultImageSizeInMB = 32
+
+    /// Just being paranoid in case size computation goes haywire and ends up computing a huge image size.
+    static let maxImageSizeInMB = 128
+
+    /// Increase image size slightly when compared to guest app size to account for extra space needed for disk image.
+    static let imageSizeMultiplier: Double = 1.1
+
+    func computeImageSizeInMB(guestAppURL: URL) -> Int {
+        do {
+            guard let enumerator = FileManager.default.enumerator(at: guestAppURL, includingPropertiesForKeys: [.totalFileAllocatedSizeKey, .contentTypeKey], options: [], errorHandler: { url, error in
+                self.logger.warning("Error enumerating guest app contents at \(url.lastPathComponent, privacy: .public) - \(error, privacy: .public)")
+                return true
+            }) else {
+                throw Failure("Failed to create directory enumerator.")
+            }
+
+            var totalSize: Int = 0
+
+            while let file = enumerator.nextObject() as? URL {
+                let values = try file.resourceValues(forKeys: [.contentTypeKey, .totalFileAllocatedSizeKey])
+
+                guard let type = values.contentType else {
+                    throw Failure("Content type not available for \(file.lastPathComponent)")
+                }
+
+                guard !type.conforms(to: .directory) else { continue }
+
+                guard let size = values.totalFileAllocatedSize else {
+                    throw Failure("File size not available for \(file.lastPathComponent)")
+                }
+
+                totalSize += size
+            }
+
+            let totalSizeMB = Int(ceil(Double(totalSize) * Self.imageSizeMultiplier)) / 1000 / 1000
+
+            logger.info("Calculated guest disk image size: \(totalSizeMB, privacy: .public)MB")
+
+            guard totalSizeMB <= Self.maxImageSizeInMB else {
+                assertionFailure("\(#function) calculated a size that's larger than the maximum allowed size. Calculated size in MB: \(totalSizeMB), max size in MB: \(Self.maxImageSizeInMB)")
+                return Self.maxImageSizeInMB
+            }
+
+            return totalSizeMB
+        } catch {
+            logger.fault("Error computing total guest disk image size. \(error, privacy: .public)")
+            return Self.defaultImageSizeInMB
+        }
+    }
+
+}
+
+extension VBBuildType {
+    var guestAdditionsImageSuffix: String? {
+        switch self {
+        case .debug: "_Debug"
+        case .betaDebug: "_Beta_Debug"
+        case .release: nil
+        case .betaRelease: "_Beta"
+        case .devRelease: "_Dev"
+        }
+    }
 }


### PR DESCRIPTION
- Use appropriate suffix in disk image file name based on current build type to avoid conflicts between multiple app versions that could be installed simultaneously (beta vs. release vs. debug, for example)
- Automatically calculate allocation size for guest disk image based on the size of the guest app itself