### PR TITLE
TSS signing check before downloading macOS builds

### DIFF
--- a/VirtualBuddy.xcodeproj/xcshareddata/xcschemes/VirtualBuddy (Managed).xcscheme
+++ b/VirtualBuddy.xcodeproj/xcshareddata/xcschemes/VirtualBuddy (Managed).xcscheme
@@ -89,11 +89,23 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-VBSimulateMobileDeviceVersion 1770.0.0"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-VerboseUILoggingEnabled YES"
             isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-VBForceSigningStatusUnsigned YES"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-VBForceSigningStatusSigned YES"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-VBForceSigningStatusRequestFailed YES"
+            isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>

--- a/VirtualBuddy/Bootstrap/VirtualBuddyApp.swift
+++ b/VirtualBuddy/Bootstrap/VirtualBuddyApp.swift
@@ -60,7 +60,6 @@ struct VirtualBuddyApp: App {
         Settings {
             PreferencesView(deepLinkSentinel: DeepLinkHandler.shared.sentinel, enableAutomaticUpdates: $updatesController.automaticUpdatesEnabled)
                 .environmentObject(settingsContainer)
-                .frame(minWidth: 420, maxWidth: .infinity, minHeight: 370, maxHeight: .infinity)
         }
     }
 }

--- a/VirtualCore/Source/Restore/Download/DownloadBackend.swift
+++ b/VirtualCore/Source/Restore/Download/DownloadBackend.swift
@@ -3,6 +3,7 @@ import Combine
 
 public enum DownloadState: Hashable {
     case idle
+    case preCheck(_ message: String)
     case downloading(_ progress: Double?, _ eta: Double?)
     case failed(_ error: String)
     case done(_ localURL: URL)

--- a/VirtualCore/Source/Settings/VBSettings.swift
+++ b/VirtualCore/Source/Settings/VBSettings.swift
@@ -26,14 +26,19 @@ public struct VBSettings: Hashable, Sendable {
             NotificationCenter.default.post(name: Self.updateChannelDidChangeNotification, object: updateChannel)
         }
     }
+    public var enableTSSCheck: Bool
 
 }
 
 extension VBSettings {
 
+    static let defaultUpdateChannel: AppUpdateChannel = .release
+    static let defaultEnableTSSCheck = true
+
     init() {
         self.libraryURL = .defaultVirtualBuddyLibraryURL
-        self.updateChannel = .release
+        self.updateChannel = Self.defaultUpdateChannel
+        self.enableTSSCheck = Self.defaultEnableTSSCheck
     }
 
     private struct Keys {
@@ -46,10 +51,16 @@ extension VBSettings {
             #endif
         }()
         static let updateChannel = "updateChannel"
+        static let enableTSSCheck = "enableTSSCheck"
     }
 
     init(with defaults: UserDefaults) throws {
+        defaults.register(defaults: [
+            Keys.enableTSSCheck: Self.defaultEnableTSSCheck
+        ])
+
         self.version = defaults.integer(forKey: Keys.version)
+        self.enableTSSCheck = defaults.bool(forKey: Keys.enableTSSCheck)
 
         if let path = defaults.string(forKey: Keys.libraryPath) {
             self.libraryURL = URL(fileURLWithPath: path)
@@ -93,6 +104,7 @@ extension VBSettings {
         defaults.set(version, forKey: Keys.version)
         defaults.set(libraryURL.path, forKey: Keys.libraryPath)
         defaults.set(updateChannel.id, forKey: Keys.updateChannel)
+        defaults.set(enableTSSCheck, forKey: Keys.enableTSSCheck)
     }
 
 }

--- a/VirtualUI/Source/Installer/Steps/Restore Image Selection/RestoreImageSelectionController.swift
+++ b/VirtualUI/Source/Installer/Steps/Restore Image Selection/RestoreImageSelectionController.swift
@@ -8,6 +8,10 @@ enum RestoreImageSelectionFocus: Hashable {
     case images
 }
 
+extension VBAPIClient {
+    static let shared = VBAPIClient()
+}
+
 @MainActor
 final class RestoreImageSelectionController: ObservableObject {
 
@@ -32,7 +36,7 @@ final class RestoreImageSelectionController: ObservableObject {
         .store(in: &cancellables)
     }
 
-    private lazy var api = VBAPIClient()
+    private lazy var api = VBAPIClient.shared
 
     private var cancellables = Set<AnyCancellable>()
 

--- a/VirtualUI/Source/Installer/Steps/RestoreImageDownloadView.swift
+++ b/VirtualUI/Source/Installer/Steps/RestoreImageDownloadView.swift
@@ -14,7 +14,7 @@ struct RestoreImageDownloadView: View {
 
     private var progress: Double? {
         switch viewModel.downloadState {
-        case .idle: 0
+        case .idle, .preCheck: 0
         case .failed: nil
         case .downloading(let progress, _): progress ?? 0
         case .done: 1
@@ -24,15 +24,16 @@ struct RestoreImageDownloadView: View {
     private var status: Text {
         switch viewModel.downloadState {
         case .idle: Text("Preparing Download")
+        case .preCheck(let message): Text(message)
         case .downloading(_, let eta): eta.flatMap { Text(formattedETA(from: $0)) } ?? Text("Downloading")
         case .done: Text("Done!")
-        case .failed(let message): Text("Download failed: \(message)")
+        case .failed(let message): Text(message)
         }
     }
 
     private var style: VirtualBuddyMonoStyle {
         switch viewModel.downloadState {
-        case .idle, .downloading: .default
+        case .idle, .downloading, .preCheck: .default
         case .failed: .failure
         case .done: .success
         }

--- a/VirtualUI/Source/Settings/PreferencesView.swift
+++ b/VirtualUI/Source/Settings/PreferencesView.swift
@@ -31,8 +31,14 @@ public struct PreferencesView: View {
 
     public var body: some View {
         Group {
-            ModernSettingsView(libraryPathText: $libraryPathText, enableAutomaticUpdates: $enableAutomaticUpdates, setLibraryPath: setLibraryPath, showOpenPanel: showOpenPanel)
-                .environmentObject(deepLinkSentinel())
+            ModernSettingsView(
+                libraryPathText: $libraryPathText,
+                enableAutomaticUpdates: $enableAutomaticUpdates,
+                enableTSSCheck: $container.settings.enableTSSCheck,
+                setLibraryPath: setLibraryPath,
+                showOpenPanel: showOpenPanel
+            )
+            .environmentObject(deepLinkSentinel())
         }
         .alert("Error", isPresented: $isShowingErrorAlert, actions: {
             Button("OK") { isShowingErrorAlert = false }
@@ -82,6 +88,7 @@ public struct PreferencesView: View {
 private struct ModernSettingsView: View {
     @Binding var libraryPathText: String
     @Binding var enableAutomaticUpdates: Bool
+    @Binding var enableTSSCheck: Bool
     var setLibraryPath: (String) -> Void
     var showOpenPanel: () -> Void
 
@@ -131,6 +138,12 @@ private struct ModernSettingsView: View {
             }
 
             Section {
+                Toggle("Check signing status before downloading macOS", isOn: $enableTSSCheck)
+            } header: {
+                Text("Services")
+            }
+
+            Section {
                 LabeledContent("Control which apps can automate VirtualBuddy") {
                     Button {
                         showingAutomationSecuritySheet = true
@@ -147,6 +160,7 @@ private struct ModernSettingsView: View {
         .sheet(isPresented: $showingAutomationSecuritySheet) {
             automationSecuritySheet
         }
+        .frame(minWidth: 440, maxWidth: 440, minHeight: 500, maxHeight: .infinity, alignment: .top)
     }
 
     @ViewBuilder


### PR DESCRIPTION
This integrates with a service that checks the signing status for a macOS build before starting the download, preventing users from spending the time/bandwidth downloading a build that will fail to install.

![CleanShot 2025-06-08 at 09 55 40](https://github.com/user-attachments/assets/5ae22461-bfd7-4f68-8adb-3e749844ce07)
