### PR TITLE
Fix excessive CPU usage during download/installation

### DIFF
--- a/VirtualBuddy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VirtualBuddy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "e8f8791c4443254b17d50018128b360ec3f9444cc33930415bf7151ecfd1277e",
+  "originHash" : "98f40922b2644e586c8b6d539ad27ccd25d4688183ddd8f20ca08988234aa81e",
   "pins" : [
     {
       "identity" : "buddykit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/insidegui/BuddyKit",
       "state" : {
-        "revision" : "34b769ec7ff1bfb7e935ed79534fad2281577096",
-        "version" : "1.6.1"
+        "revision" : "27dcaaa5075068cebc4372dee76801f6d862556b",
+        "version" : "1.7.0"
       }
     },
     {

--- a/VirtualUI/Source/Installer/Steps/Restore Image Selection/Components/VirtualBuddyMonoProgressView.swift
+++ b/VirtualUI/Source/Installer/Steps/Restore Image Selection/Components/VirtualBuddyMonoProgressView.swift
@@ -53,13 +53,9 @@ private struct RamRodProgressView: View {
 
     var body: some View {
         ZStack {
-            Rectangle()
-                .fill(Color(white: 0.16))
-            GeometryReader { proxy in
-                Color(white: 0.82)
-                    .frame(width: proxy.size.width * (progress / 1.0), alignment: .leading)
-                    .animation(.linear, value: progress)
-            }
+            Rectangle().fill(Color(white: 0.16))
+
+            ProgressBarShapeView(progress: progress)
         }
             .clipShape(shape)
             .overlay(shape.stroke(Color(white: 0.25), lineWidth: 1))
@@ -68,6 +64,62 @@ private struct RamRodProgressView: View {
 
     private var shape: some InsettableShape {
         Capsule(style: .continuous)
+    }
+}
+
+/**
+ You see, animating a white rectangle growing in width is a very expensive operation that SwiftUI
+ is completely unable to do by itself without consuming an unhealthy amount of CPU,
+ so this uses Core Animation instead to offload that expensive computation to the WindowServer/GPU.
+ */
+private struct ProgressBarShapeView: NSViewRepresentable {
+    typealias NSViewType = _Representable
+
+    var progress: Double = 0
+
+    func makeNSView(context: Context) -> _Representable {
+        _Representable(frame: .zero)
+    }
+
+    func updateNSView(_ nsView: _Representable, context: Context) {
+        nsView.progress = progress
+    }
+
+    final class _Representable: NSView {
+        private lazy var bar = CALayer()
+
+        @Invalidating(.layout)
+        var progress: Double = 0
+
+        override init(frame frameRect: NSRect) {
+            super.init(frame: frameRect)
+
+            platformLayer.addSublayer(bar)
+            bar.backgroundColor = .white
+            bar.anchorPoint = CGPoint(x: 0, y: 0.5)
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError()
+        }
+
+        override func layout() {
+            super.layout()
+
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+
+            bar.position = CGPoint(x: bounds.minX, y: bounds.midY)
+            bar.frame.size.height = bounds.height
+
+            CATransaction.commit()
+
+            CATransaction.begin()
+            CATransaction.setAnimationDuration(0.2)
+            CATransaction.setAnimationTimingFunction(.init(name: .linear))
+            bar.frame.size.width = bounds.width * progress
+            CATransaction.commit()
+        }
     }
 }
 

--- a/VirtualUI/Source/Installer/Steps/RestoreImageDownloadView.swift
+++ b/VirtualUI/Source/Installer/Steps/RestoreImageDownloadView.swift
@@ -11,9 +11,10 @@ import Combine
 
 struct RestoreImageDownloadView: View {
     @EnvironmentObject var viewModel: VMInstallationViewModel
+    @State private var downloadState = DownloadState.idle
 
     private var progress: Double? {
-        switch viewModel.downloadState {
+        switch downloadState {
         case .idle, .preCheck: 0
         case .failed: nil
         case .downloading(let progress, _): progress ?? 0
@@ -22,7 +23,7 @@ struct RestoreImageDownloadView: View {
     }
 
     private var status: Text {
-        switch viewModel.downloadState {
+        switch downloadState {
         case .idle: Text("Preparing Download")
         case .preCheck(let message): Text(message)
         case .downloading(_, let eta): eta.flatMap { Text(formattedETA(from: $0)) } ?? Text("Downloading")
@@ -32,7 +33,7 @@ struct RestoreImageDownloadView: View {
     }
 
     private var style: VirtualBuddyMonoStyle {
-        switch viewModel.downloadState {
+        switch downloadState {
         case .idle, .downloading, .preCheck: .default
         case .failed: .failure
         case .done: .success
@@ -45,6 +46,7 @@ struct RestoreImageDownloadView: View {
             status: status,
             style: style
         )
+        .onReceive(viewModel.$downloadState) { downloadState = $0 }
     }
 
     private func formattedETA(from eta: Double) -> String {

--- a/VirtualUI/Source/Installer/VMInstallationViewModel.swift
+++ b/VirtualUI/Source/Installer/VMInstallationViewModel.swift
@@ -166,7 +166,7 @@ final class VMInstallationViewModel: ObservableObject, @unchecked Sendable {
     }
 
     @Published private(set) var downloader: DownloadBackend?
-    @Published private(set) var downloadState: DownloadState = .idle
+    @SubjectPublisher private(set) var downloadState: DownloadState = .idle
 
     private func validate() {
         disableNextButton = !data.canContinue(from: step)
@@ -354,7 +354,10 @@ final class VMInstallationViewModel: ObservableObject, @unchecked Sendable {
     private func startDownload(with url: URL) {
         let backend = createDownloadBackend(cookie: data.cookie)
 
-        backend.statePublisher.assign(to: &$downloadState)
+        backend.statePublisher.sink { [weak self] state in
+            self?.downloadState = state
+        }
+        .store(in: &cancellables)
 
         self.downloader = backend
 


### PR DESCRIPTION
- Wizard view body was being refreshed too frequently due to updates from `@Published` property in view model with download state
- Progress bar view implementation in SwiftUI by itself could use ~20% CPU; tried a bunch of different approaches which all resulted in similar footprint, ended up using Core Animation instead ¯\_(ツ)_/¯ 