### PR TITLE
Delete "DRM Protected Video" screenshots/thumbnails

### DIFF
--- a/VirtualBuddy.xcodeproj/project.pbxproj
+++ b/VirtualBuddy.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 		F49B82FC2E034EAD00395F87 /* WHDesktopPictureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B82FB2E034EAD00395F87 /* WHDesktopPictureService.swift */; };
 		F49B83002E034F6800395F87 /* NSImage+DesktopPicture.m in Sources */ = {isa = PBXBuildFile; fileRef = F49B82FF2E034F6800395F87 /* NSImage+DesktopPicture.m */; };
 		F49B83012E034F6800395F87 /* NSImage+DesktopPicture.h in Headers */ = {isa = PBXBuildFile; fileRef = F49B82FE2E034F6800395F87 /* NSImage+DesktopPicture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F49B832B2E04593A00395F87 /* NSImage+DRMProtected.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B832A2E04593100395F87 /* NSImage+DRMProtected.swift */; };
 		F49FD87D2DFB68F50019D638 /* VMImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49FD87C2DFB68F20019D638 /* VMImporter.swift */; };
 		F49FD87F2DFB6B670019D638 /* VMImporterRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49FD87E2DFB6B630019D638 /* VMImporterRegistry.swift */; };
 		F49FD8812DFB6CDD0019D638 /* UTMImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49FD8802DFB6CD80019D638 /* UTMImporter.swift */; };
@@ -723,6 +724,7 @@
 		F49B82FB2E034EAD00395F87 /* WHDesktopPictureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WHDesktopPictureService.swift; sourceTree = "<group>"; };
 		F49B82FE2E034F6800395F87 /* NSImage+DesktopPicture.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSImage+DesktopPicture.h"; sourceTree = "<group>"; };
 		F49B82FF2E034F6800395F87 /* NSImage+DesktopPicture.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSImage+DesktopPicture.m"; sourceTree = "<group>"; };
+		F49B832A2E04593100395F87 /* NSImage+DRMProtected.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSImage+DRMProtected.swift"; sourceTree = "<group>"; };
 		F49FD87C2DFB68F20019D638 /* VMImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMImporter.swift; sourceTree = "<group>"; };
 		F49FD87E2DFB6B630019D638 /* VMImporterRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMImporterRegistry.swift; sourceTree = "<group>"; };
 		F49FD8802DFB6CD80019D638 /* UTMImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTMImporter.swift; sourceTree = "<group>"; };
@@ -1926,6 +1928,7 @@
 			isa = PBXGroup;
 			children = (
 				F4E7DF912BB3338900C459FC /* NSImage+HEIC.swift */,
+				F49B832A2E04593100395F87 /* NSImage+DRMProtected.swift */,
 			);
 			path = Screenshot;
 			sourceTree = "<group>";
@@ -2574,6 +2577,7 @@
 				F44C00FB2889CE1600640BF5 /* VBVirtualMachine+Virtualization.swift in Sources */,
 				F453C4892DF1CDA0007EAD5F /* DownloadBackend.swift in Sources */,
 				F4F9B418284CE12000F21737 /* VBSettingsContainer.swift in Sources */,
+				F49B832B2E04593A00395F87 /* NSImage+DRMProtected.swift in Sources */,
 				F4E7DF972BB33E1700C459FC /* VMLibraryController+SavedState.swift in Sources */,
 				F48E0D0C2888760D0080DDFA /* VBMacDevice+Storage.swift in Sources */,
 				F465C3AE284F93A5006E9ED4 /* VBAPIClient.swift in Sources */,

--- a/VirtualBuddy.xcodeproj/xcshareddata/xcschemes/VirtualBuddy (Managed).xcscheme
+++ b/VirtualBuddy.xcodeproj/xcshareddata/xcschemes/VirtualBuddy (Managed).xcscheme
@@ -115,6 +115,10 @@
             argument = "-VBTestImportSkipConfirmation YES"
             isEnabled = "NO">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-VBAlwaysAttemptLegacyThumbnailMigration YES"
+            isEnabled = "NO">
+         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction

--- a/VirtualCore/Source/Models/VBVirtualMachine+Screenshot.swift
+++ b/VirtualCore/Source/Models/VBVirtualMachine+Screenshot.swift
@@ -22,6 +22,10 @@ public extension VBVirtualMachine {
         return try? screenshot?.vb_createThumbnail(at: thumbnailURL)
     }
 
+    func invalidateScreenshot() throws {
+        try deleteMetadataFile(named: Self.screenshotFileName)
+    }
+
     func invalidateThumbnail() throws {
         try deleteMetadataFile(named: Self.thumbnailFileName)
     }

--- a/VirtualCore/Source/Virtualization/Screenshot/NSImage+DRMProtected.swift
+++ b/VirtualCore/Source/Virtualization/Screenshot/NSImage+DRMProtected.swift
@@ -1,0 +1,37 @@
+import Cocoa
+import BuddyKit
+import Vision
+
+@available(macOS 15.0, *)
+extension NSImage {
+    /// This is kinda silly.
+    ///
+    /// All this does is it attempts to detect the string "DRM Protected" inside of a thumbnail image.
+    /// This is to work around a bug that happened in macOS 26 where screenshots used for thumbnails
+    /// would display a "DRM Protected Video" message with a black background.
+    ///
+    /// Some users ended up with these bad thumbnails in their library and with the new background hash
+    /// thumbnails I didn't want them to get a black background with a white blurry blob as their VM thumbnail.
+    ///
+    /// See: https://github.com/insidegui/VirtualBuddy/discussions/533
+    func detectDRMProtectedVideoBug() async -> Bool {
+        guard let cgImage else { return false }
+
+        var request = RecognizeTextRequest()
+        request.automaticallyDetectsLanguage = false
+        request.recognitionLanguages = [.init(components: .init(languageCode: .english, script: nil, region: nil))]
+        request.recognitionLevel = .fast
+        request.minimumTextHeightFraction = 0.05
+
+        guard let observations = try? await request.perform(on: cgImage) else { return false }
+
+        return observations.contains(where: { $0.text.localizedCaseInsensitiveContains("DRM Protected") })
+    }
+}
+
+@available(macOS 15.0, *)
+private extension RecognizedTextObservation {
+    var text: String {
+        topCandidates(1).first?.string ?? ""
+    }
+}

--- a/VirtualCore/Source/Virtualization/VMLibraryController.swift
+++ b/VirtualCore/Source/Virtualization/VMLibraryController.swift
@@ -228,16 +228,17 @@ public final class VMLibraryController: ObservableObject {
         #endif
     }
 
+    private static let migratedLegacyThumbnailBackgroundHashesDefaultsKey = "migratedLegacyThumbnailBackgroundHashes_2"
     private var migratedLegacyThumbnailBackgroundHashes: Bool {
         get {
             guard !alwaysAttemptLegacyThumbnailMigration else { return false }
 
-            return UserDefaults.standard.bool(forKey: #function)
+            return UserDefaults.standard.bool(forKey: Self.migratedLegacyThumbnailBackgroundHashesDefaultsKey)
         }
         set {
             guard !alwaysAttemptLegacyThumbnailMigration else { return }
 
-            UserDefaults.standard.set(newValue, forKey: #function)
+            UserDefaults.standard.set(newValue, forKey: Self.migratedLegacyThumbnailBackgroundHashesDefaultsKey)
         }
     }
 

--- a/VirtualCore/Source/Virtualization/VMLibraryController.swift
+++ b/VirtualCore/Source/Virtualization/VMLibraryController.swift
@@ -220,9 +220,25 @@ public final class VMLibraryController: ObservableObject {
 
     // MARK: - Migration
 
+    private var alwaysAttemptLegacyThumbnailMigration: Bool {
+        #if DEBUG
+        UserDefaults.standard.bool(forKey: "VBAlwaysAttemptLegacyThumbnailMigration")
+        #else
+        false
+        #endif
+    }
+
     private var migratedLegacyThumbnailBackgroundHashes: Bool {
-        get { UserDefaults.standard.bool(forKey: #function) }
-        set { UserDefaults.standard.set(newValue, forKey: #function) }
+        get {
+            guard !alwaysAttemptLegacyThumbnailMigration else { return false }
+
+            return UserDefaults.standard.bool(forKey: #function)
+        }
+        set {
+            guard !alwaysAttemptLegacyThumbnailMigration else { return }
+
+            UserDefaults.standard.set(newValue, forKey: #function)
+        }
     }
 
     private func migrateBackgroundHashesForLegacyThumbnails() {
@@ -253,6 +269,17 @@ public final class VMLibraryController: ObservableObject {
                     guard let thumbnail = machine.thumbnailImage() else {
                         logger.debug("Ignoring \(machine.name) for background hash migration because it doesn't have a thumbnail.")
                         continue
+                    }
+
+                    if #available(macOS 15.0, *) {
+                        let isDRMProtectedBug = await thumbnail.detectDRMProtectedVideoBug()
+
+                        guard !isDRMProtectedBug else {
+                            logger.notice("Invalidating thumbnail for \(machine.name): detected \"DRM Protected Video\" bug in its thumbnail.")
+                            try machine.invalidateThumbnail()
+                            try machine.invalidateScreenshot()
+                            continue
+                        }
                     }
 
                     let hash = try thumbnail.blurHash(numberOfComponents: (.vbBlurHashSize, .vbBlurHashSize))


### PR DESCRIPTION
When migrating thumbnails, the app will detect the bug described in https://github.com/insidegui/VirtualBuddy/discussions/533 and delete the bad screenshot/thumbnail.