### PR TITLE
Fix thumbnail corruption caused by VM shutdown

### DIFF
--- a/VirtualBuddy.xcodeproj/project.pbxproj
+++ b/VirtualBuddy.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 		F49B83012E034F6800395F87 /* NSImage+DesktopPicture.h in Headers */ = {isa = PBXBuildFile; fileRef = F49B82FE2E034F6800395F87 /* NSImage+DesktopPicture.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F49B832B2E04593A00395F87 /* NSImage+DRMProtected.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B832A2E04593100395F87 /* NSImage+DRMProtected.swift */; };
 		F49B832D2E046B8D00395F87 /* GuestAppConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B832C2E046B8D00395F87 /* GuestAppConfigurationView.swift */; };
+		F49B83712E04837400395F87 /* CGImage+FullyTransparent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B83702E04837400395F87 /* CGImage+FullyTransparent.swift */; };
 		F49FD87D2DFB68F50019D638 /* VMImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49FD87C2DFB68F20019D638 /* VMImporter.swift */; };
 		F49FD87F2DFB6B670019D638 /* VMImporterRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49FD87E2DFB6B630019D638 /* VMImporterRegistry.swift */; };
 		F49FD8812DFB6CDD0019D638 /* UTMImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49FD8802DFB6CD80019D638 /* UTMImporter.swift */; };
@@ -727,6 +728,7 @@
 		F49B82FF2E034F6800395F87 /* NSImage+DesktopPicture.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSImage+DesktopPicture.m"; sourceTree = "<group>"; };
 		F49B832A2E04593100395F87 /* NSImage+DRMProtected.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSImage+DRMProtected.swift"; sourceTree = "<group>"; };
 		F49B832C2E046B8D00395F87 /* GuestAppConfigurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestAppConfigurationView.swift; sourceTree = "<group>"; };
+		F49B83702E04837400395F87 /* CGImage+FullyTransparent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGImage+FullyTransparent.swift"; sourceTree = "<group>"; };
 		F49FD87C2DFB68F20019D638 /* VMImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMImporter.swift; sourceTree = "<group>"; };
 		F49FD87E2DFB6B630019D638 /* VMImporterRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMImporterRegistry.swift; sourceTree = "<group>"; };
 		F49FD8802DFB6CD80019D638 /* UTMImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTMImporter.swift; sourceTree = "<group>"; };
@@ -1514,6 +1516,7 @@
 			children = (
 				F49B82FE2E034F6800395F87 /* NSImage+DesktopPicture.h */,
 				F49B82FF2E034F6800395F87 /* NSImage+DesktopPicture.m */,
+				F49B83702E04837400395F87 /* CGImage+FullyTransparent.swift */,
 				F49B82FB2E034EAD00395F87 /* WHDesktopPictureService.swift */,
 			);
 			path = DesktopPicture;
@@ -2654,6 +2657,7 @@
 				F4D305B029B900860006E748 /* SystemNotification.swift in Sources */,
 				F42862372AE947C90052F029 /* WHPayload.swift in Sources */,
 				F4BE581329BA6E0D00C5525C /* DefaultsDomainDescriptor.swift in Sources */,
+				F49B83712E04837400395F87 /* CGImage+FullyTransparent.swift in Sources */,
 				F4BE581129BA6DFC00C5525C /* DefaultsImportController.swift in Sources */,
 				F49B82FC2E034EAD00395F87 /* WHDesktopPictureService.swift in Sources */,
 				F4D305B229B907A10006E748 /* WHPing.swift in Sources */,

--- a/VirtualWormhole/Source/Services/DesktopPicture/CGImage+FullyTransparent.swift
+++ b/VirtualWormhole/Source/Services/DesktopPicture/CGImage+FullyTransparent.swift
@@ -1,0 +1,77 @@
+//
+//  CGImage+FullyTransparent.swift
+//  VirtualBuddy
+//
+//  Created by Guilherme Rambo on 19/06/25.
+//
+
+import Cocoa
+import CoreImage
+import CoreImage.CIFilterBuiltins
+
+private let transparentCheckContext = CIContext(options: [.workingColorSpace: NSNull()])
+
+extension CGImage {
+    /// Returns `true` if the image is fully transparent or has width and height equal to zero.
+    func isFullyTransparent() -> Bool {
+        /// Zero size image is considered fully transparent.
+        guard width > 0, height > 0 else { return true }
+
+        /// If image has no alpha, then it can't be fully transparent.
+        switch alphaInfo {
+        case .none, .noneSkipFirst, .noneSkipLast:
+            return false
+        default:
+            break
+        }
+
+        let ciImage = CIImage(cgImage: self)
+
+        let filter = CIFilter.areaMaximumAlpha()
+        filter.inputImage = ciImage
+        filter.extent = ciImage.extent
+
+        guard let reduced = filter.outputImage else {
+            assertionFailure("Error reducing image area maximum alpha")
+            return false
+        }
+
+        var alpha: UInt32 = 0
+
+        transparentCheckContext
+            .render(
+                reduced,
+                toBitmap: &alpha,
+                rowBytes: 4,
+                bounds: CGRect(x: 0, y: 0, width: 1, height: 1),
+                format: .A8,
+                colorSpace: nil
+            )
+
+        return alpha == 0
+    }
+
+    static func load(from url: URL) throws -> CGImage {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+            throw CocoaError(.fileReadNoSuchFile)
+        }
+
+        guard let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            throw CocoaError(.coderInvalidValue)
+        }
+
+        return cgImage
+    }
+
+    static func load(from data: Data) throws -> CGImage {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+            throw CocoaError(.coderValueNotFound)
+        }
+
+        guard let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            throw CocoaError(.coderInvalidValue)
+        }
+
+        return cgImage
+    }
+}

--- a/VirtualWormhole/Source/Services/DesktopPicture/NSImage+DesktopPicture.h
+++ b/VirtualWormhole/Source/Services/DesktopPicture/NSImage+DesktopPicture.h
@@ -4,7 +4,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSImage (DesktopPicture)
 
-@property (nonatomic, readonly, class) NSImage *_Nullable desktopPicture;
+@property (nonatomic, readonly, class) NSImage *_Nullable desktopPicture NS_SWIFT_UI_ACTOR;
 
 + (void)desktopPictureForScreen:(NSScreen *)screen completion:(void(^)(NSImage *_Nullable desktopPicture))completion;
 

--- a/VirtualWormhole/Source/WormholeManager.swift
+++ b/VirtualWormhole/Source/WormholeManager.swift
@@ -315,6 +315,25 @@ public final class WormholeManager: NSObject, ObservableObject, WormholeMultiple
         return AsyncStream { await iterator.next() }
     }
 
+    /// Can be called on the guest to force-send the current desktop picture.
+    public func sendDesktopPicture() async {
+        guard side == .guest else { return }
+
+        do {
+            guard let desktopPictureService = service(WHDesktopPictureService.self) else {
+                throw CocoaError(.coderValueNotFound, userInfo: [NSLocalizedDescriptionKey: "Desktop picture service not available"])
+            }
+
+            logger.debug("Sending desktop picture")
+
+            await desktopPictureService.sendDesktopPicture()
+
+            logger.debug("Finished sending desktop picture")
+        } catch {
+            logger.error("Send desktop picture failed - \(error, privacy: .public)")
+        }
+    }
+
     private func ensurePeerAvailable(_ peerID: WHPeerID) throws {
         guard peers[peerID] != nil else {
             throw CocoaError(.coderValueNotFound, userInfo: [NSLocalizedDescriptionKey: "Peer \(peerID) is not registered"])


### PR DESCRIPTION
Sometimes during VM shutdown the desktop window used to capture the wallpaper image will generate a fully transparent image, which would cause a black background to show up as the VM thumbnail. This fixes that by not sending the desktop picture message when the generated image is fully transparent.