### PR TITLE
Use ASIF disk image by default on macOS 26 host

### DIFF
--- a/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
+++ b/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
@@ -79,15 +79,36 @@ public struct VBManagedDiskImage: Identifiable, Hashable, Codable {
         case raw
         case dmg
         case sparse
+        case asif
+
+        /// The default format for the boot disk image in the current environment.
+        static let defaultBootDisk: Format = {
+            if #available(macOS 26, *) {
+                .asif
+            } else {
+                .raw
+            }
+        }()
 
         var fileExtension: String {
             switch self {
-            case .raw:
-                return "img"
-            case .dmg:
-                return "dmg"
-            case .sparse:
-                return "sparseimage"
+            case .raw: "img"
+            case .dmg: "dmg"
+            case .sparse: "sparseimage"
+            case .asif: "asif"
+            }
+        }
+
+        var isSupported: Bool {
+            switch self {
+            case .raw, .dmg, .sparse:
+                true
+            case .asif:
+                if #available(macOS 26, *) {
+                    true
+                } else {
+                    false
+                }
             }
         }
     }
@@ -102,7 +123,7 @@ public struct VBManagedDiskImage: Identifiable, Hashable, Codable {
             id: "__BOOT__",
             filename: "Disk",
             size: Self.defaultBootDiskImageSize,
-            format: .raw
+            format: .defaultBootDisk
         )
     }
     

--- a/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
+++ b/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
@@ -82,13 +82,13 @@ public struct VBManagedDiskImage: Identifiable, Hashable, Codable {
         case asif
 
         /// The default format for the boot disk image in the current environment.
-        static let defaultBootDisk: Format = {
-            if #available(macOS 26, *) {
+        static var defaultBootDisk: Format {
+            if #available(macOS 26, *), VBSettings.current.bootDiskImagesUseASIF {
                 .asif
             } else {
                 .raw
             }
-        }()
+        }
 
         var fileExtension: String {
             switch self {
@@ -117,7 +117,8 @@ public struct VBManagedDiskImage: Identifiable, Hashable, Codable {
     public var filename: String
     public var size: UInt64
     public var format: Format = .sparse
-    
+
+    // Not a stored property because Format.defaultBootDisk can change based on user preferences.
     public static var managedBootImage: VBManagedDiskImage {
         VBManagedDiskImage(
             id: "__BOOT__",

--- a/VirtualCore/Source/Settings/VBSettings.swift
+++ b/VirtualCore/Source/Settings/VBSettings.swift
@@ -32,6 +32,9 @@ public struct VBSettings: Hashable, Sendable {
     /// Currently not exposed in the UI.
     public var showDesktopPictureThumbnails: Bool
 
+    /// Enables using the new ASIF format for boot disk images (requires macOS 26+ host).
+    public var bootDiskImagesUseASIF: Bool
+
 }
 
 extension VBSettings {
@@ -39,12 +42,20 @@ extension VBSettings {
     static let defaultUpdateChannel: AppUpdateChannel = .release
     static let defaultEnableTSSCheck = true
     static let defaultShowDesktopPictureThumbnails = false
+    static let defaultBootDiskImagesUseASIF: Bool = {
+        if #available(macOS 26, *) {
+            true
+        } else {
+            false
+        }
+    }()
 
     init() {
         self.libraryURL = .defaultVirtualBuddyLibraryURL
         self.updateChannel = Self.defaultUpdateChannel
         self.enableTSSCheck = Self.defaultEnableTSSCheck
         self.showDesktopPictureThumbnails = Self.defaultShowDesktopPictureThumbnails
+        self.bootDiskImagesUseASIF = Self.defaultBootDiskImagesUseASIF
     }
 
     private struct Keys {
@@ -59,6 +70,7 @@ extension VBSettings {
         static let updateChannel = "updateChannel"
         static let enableTSSCheck = "enableTSSCheck"
         static let showDesktopPictureThumbnails = "showDesktopPictureThumbnails"
+        static let bootDiskImagesUseASIF = "bootDiskImagesUseASIF"
     }
 
     init(with defaults: UserDefaults) throws {
@@ -69,6 +81,7 @@ extension VBSettings {
         self.version = defaults.integer(forKey: Keys.version)
         self.enableTSSCheck = defaults.bool(forKey: Keys.enableTSSCheck)
         self.showDesktopPictureThumbnails = defaults.bool(forKey: Keys.showDesktopPictureThumbnails)
+        self.bootDiskImagesUseASIF = defaults.bool(forKey: Keys.bootDiskImagesUseASIF)
 
         if let path = defaults.string(forKey: Keys.libraryPath) {
             self.libraryURL = URL(fileURLWithPath: path)
@@ -114,6 +127,7 @@ extension VBSettings {
         defaults.set(updateChannel.id, forKey: Keys.updateChannel)
         defaults.set(enableTSSCheck, forKey: Keys.enableTSSCheck)
         defaults.set(showDesktopPictureThumbnails, forKey: Keys.showDesktopPictureThumbnails)
+        defaults.set(bootDiskImagesUseASIF, forKey: Keys.bootDiskImagesUseASIF)
     }
 
 }

--- a/VirtualUI/Source/Settings/PreferencesView.swift
+++ b/VirtualUI/Source/Settings/PreferencesView.swift
@@ -35,6 +35,7 @@ public struct PreferencesView: View {
                 libraryPathText: $libraryPathText,
                 enableAutomaticUpdates: $enableAutomaticUpdates,
                 enableTSSCheck: $container.settings.enableTSSCheck,
+                enableASIFDiskImages: $container.settings.bootDiskImagesUseASIF,
                 setLibraryPath: setLibraryPath,
                 showOpenPanel: showOpenPanel
             )
@@ -89,6 +90,8 @@ private struct ModernSettingsView: View {
     @Binding var libraryPathText: String
     @Binding var enableAutomaticUpdates: Bool
     @Binding var enableTSSCheck: Bool
+    @Binding var enableASIFDiskImages: Bool
+
     var setLibraryPath: (String) -> Void
     var showOpenPanel: () -> Void
 
@@ -127,6 +130,26 @@ private struct ModernSettingsView: View {
             } footer: {
                 Text("This is where VirtualBuddy will store your virtual machines and installer images downloaded within the app.")
                     .foregroundStyle(.secondary)
+            }
+
+            if #available(macOS 26, *) {
+                Section {
+                    Picker("Boot Image Format", selection: $enableASIFDiskImages) {
+                        Text("Most Efficient")
+                            .tag(true)
+                        Text("Most Compatible")
+                            .tag(false)
+                    }
+                } header: {
+                    Text("Disk Images")
+                } footer: {
+                    Text("""
+                    Choose the disk image format that will be used when creating new virtual machines.
+                    
+                    - Most Efficient: uses the new ASIF format, requires the host to be running macOS 26 or later.
+                    - Most Compatible: uses a raw image format, compatible with all versions of macOS supported by VirtualBuddy.
+                    """)
+                }
             }
 
             Section {


### PR DESCRIPTION
Adopt the new ASIF disk image format by default on macOS 26 hosts.

There's a new setting to change the default back to raw disk images for those who need to share virtual machines with older hosts.

See https://github.com/insidegui/VirtualBuddy/discussions/530