### PR TITLE
Allow Command+R to refresh catalog when browsing OS versions

### DIFF
--- a/VirtualUI/Source/Installer/Steps/Restore Image Selection/RestoreImageSelectionController.swift
+++ b/VirtualUI/Source/Installer/Steps/Restore Image Selection/RestoreImageSelectionController.swift
@@ -25,8 +25,6 @@ final class RestoreImageSelectionController: ObservableObject {
             guard let self else { return }
             guard let group else { return }
 
-            guard selectedRestoreImage?.image.group != group.id else { return }
-
             /// Selected group has changed, update available channel groups, images, and selected image.
             let updatedChannelGroups = ChannelGroup.groups(with: group.restoreImages)
             channelGroups = updatedChannelGroups
@@ -79,7 +77,7 @@ final class RestoreImageSelectionController: ObservableObject {
     private var inputCatalog: SoftwareCatalog?
     private var guestType = VBGuestType.mac
 
-    func loadRestoreImageOptions(for guest: VBGuestType) {
+    func loadRestoreImageOptions(for guest: VBGuestType, skipCache: Bool = false) {
         logger.debug("Loading restore image options.")
 
         guestType = guest
@@ -103,7 +101,7 @@ final class RestoreImageSelectionController: ObservableObject {
                 }
                 #endif
 
-                let catalog = try await api.fetchRestoreImages(for: guest)
+                let catalog = try await api.fetchRestoreImages(for: guest, skipCache: skipCache)
                 inputCatalog = catalog
 
                 await refreshResolvedCatalog(with: catalog)

--- a/VirtualUI/Source/Installer/Steps/Restore Image Selection/RestoreImageSelectionStep.swift
+++ b/VirtualUI/Source/Installer/Steps/Restore Image Selection/RestoreImageSelectionStep.swift
@@ -32,9 +32,7 @@ struct RestoreImageSelectionStep: View {
         .frame(maxWidth: .infinity)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .environmentObject(controller)
-        .task(id: viewModel.data.systemType) {
-            controller.loadRestoreImageOptions(for: viewModel.data.systemType)
-        }
+        .task(id: viewModel.data.systemType) { loadOptions() }
         .task(id: controller.selectedGroup) {
             if let group = controller.selectedGroup {
                 viewModel.data.backgroundHash = BlurHashToken(value: group.darkImage.thumbnail.blurHash)
@@ -42,6 +40,21 @@ struct RestoreImageSelectionStep: View {
                 viewModel.data.backgroundHash = .virtualBuddyBackground
             }
         }
+        .toolbar {
+            ToolbarItemGroup(placement: .primaryAction) {
+                Button {
+                    loadOptions(skipCache: true)
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .help(Text("Reload"))
+                .keyboardShortcut("r", modifiers: .command)
+            }
+        }
+    }
+
+    private func loadOptions(skipCache: Bool = false) {
+        controller.loadRestoreImageOptions(for: viewModel.data.systemType, skipCache: skipCache)
     }
 
 }


### PR DESCRIPTION
Adds a refresh button to the toolbar when browsing the catalog. Clicking the button or pressing Command+R will reload the remote catalog skipping the local cache.

<img width="912" alt="image" src="https://github.com/user-attachments/assets/e3dc2647-503a-4b98-a22d-dafa58c00a81" />
