### PR TITLE
Resilient matching of local restore image with catalog content

### DIFF
--- a/VirtualBuddy.xcodeproj/project.pbxproj
+++ b/VirtualBuddy.xcodeproj/project.pbxproj
@@ -292,6 +292,9 @@
 		F4C18A5328491B9D00335EC7 /* VirtualWormhole.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F4C189E02848F59F00335EC7 /* VirtualWormhole.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F4C2374D2888A462001FF286 /* VolumeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C2374C2888A462001FF286 /* VolumeUtils.swift */; };
 		F4C237502888AF67001FF286 /* LogStreamer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C2374F2888AF67001FF286 /* LogStreamer.swift */; };
+		F4C947BF2E0B0F71001ACC91 /* URL+ExtendedAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C947BE2E0B0F71001ACC91 /* URL+ExtendedAttributes.swift */; };
+		F4C947D62E0B12D0001ACC91 /* String+AppleOSBuild.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C947D52E0B12D0001ACC91 /* String+AppleOSBuild.swift */; };
+		F4C947DA2E0B1E5D001ACC91 /* SoftwareCatalog+DownloadMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C947D92E0B1E5D001ACC91 /* SoftwareCatalog+DownloadMatching.swift */; };
 		F4CD13202E05A5780067DC75 /* FileSystemPathFormControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CD131F2E05A5780067DC75 /* FileSystemPathFormControl.swift */; };
 		F4CD133C2E05A9DF0067DC75 /* OpenVirtualBuddySettingsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CD133B2E05A9DF0067DC75 /* OpenVirtualBuddySettingsAction.swift */; };
 		F4CD133E2E05AB280067DC75 /* BackwardsCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CD133D2E05AB280067DC75 /* BackwardsCompatibility.swift */; };
@@ -797,6 +800,9 @@
 		F4C18A4D28491B8500335EC7 /* VirtualBuddyGuest.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VirtualBuddyGuest.entitlements; sourceTree = "<group>"; };
 		F4C2374C2888A462001FF286 /* VolumeUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeUtils.swift; sourceTree = "<group>"; };
 		F4C2374F2888AF67001FF286 /* LogStreamer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogStreamer.swift; sourceTree = "<group>"; };
+		F4C947BE2E0B0F71001ACC91 /* URL+ExtendedAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+ExtendedAttributes.swift"; sourceTree = "<group>"; };
+		F4C947D52E0B12D0001ACC91 /* String+AppleOSBuild.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+AppleOSBuild.swift"; sourceTree = "<group>"; };
+		F4C947D92E0B1E5D001ACC91 /* SoftwareCatalog+DownloadMatching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SoftwareCatalog+DownloadMatching.swift"; sourceTree = "<group>"; };
 		F4CD131F2E05A5780067DC75 /* FileSystemPathFormControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemPathFormControl.swift; sourceTree = "<group>"; };
 		F4CD133B2E05A9DF0067DC75 /* OpenVirtualBuddySettingsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenVirtualBuddySettingsAction.swift; sourceTree = "<group>"; };
 		F4CD133D2E05AB280067DC75 /* BackwardsCompatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackwardsCompatibility.swift; sourceTree = "<group>"; };
@@ -1252,6 +1258,8 @@
 			isa = PBXGroup;
 			children = (
 				F453C4162DF0B43D007EAD5F /* BlurHashEncode.swift */,
+				F4C947BE2E0B0F71001ACC91 /* URL+ExtendedAttributes.swift */,
+				F4C947D52E0B12D0001ACC91 /* String+AppleOSBuild.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1263,8 +1271,9 @@
 				F453C4172DF0B43D007EAD5F /* Utilities */,
 				F453C4182DF0B43D007EAD5F /* LegacyCatalog.swift */,
 				F453C4192DF0B43D007EAD5F /* MobileDeviceFramework.swift */,
-				F453C41A2DF0B43D007EAD5F /* ResolvedCatalog.swift */,
 				F453C41B2DF0B43D007EAD5F /* SoftwareCatalog.swift */,
+				F453C41A2DF0B43D007EAD5F /* ResolvedCatalog.swift */,
+				F4C947D92E0B1E5D001ACC91 /* SoftwareCatalog+DownloadMatching.swift */,
 			);
 			path = VirtualCatalog;
 			sourceTree = "<group>";
@@ -2619,6 +2628,7 @@
 				F45502162DF45E53005582A4 /* VBSettings+CatalogDownload.swift in Sources */,
 				F44C00FB2889CE1600640BF5 /* VBVirtualMachine+Virtualization.swift in Sources */,
 				F453C4892DF1CDA0007EAD5F /* DownloadBackend.swift in Sources */,
+				F4C947DA2E0B1E5D001ACC91 /* SoftwareCatalog+DownloadMatching.swift in Sources */,
 				F4F9B418284CE12000F21737 /* VBSettingsContainer.swift in Sources */,
 				F49B832B2E04593A00395F87 /* NSImage+DRMProtected.swift in Sources */,
 				F4E7DF972BB33E1700C459FC /* VMLibraryController+SavedState.swift in Sources */,
@@ -2663,6 +2673,7 @@
 				F49FD8812DFB6CDD0019D638 /* UTMImporter.swift in Sources */,
 				F443620A29B7947A00745B43 /* GuestAdditionsDiskImage.swift in Sources */,
 				F485B9232BB306AF004B3C2B /* VBDebugUtil.m in Sources */,
+				F4C947BF2E0B0F71001ACC91 /* URL+ExtendedAttributes.swift in Sources */,
 				F47BCDD72C5D2B4600165191 /* CatalogExtensions.swift in Sources */,
 				F4BE9C7827FF055100B648F8 /* MacOSVirtualMachineConfigurationHelper.swift in Sources */,
 				F4510A782AE2A16F00E24DD9 /* WeakReference.swift in Sources */,
@@ -2675,6 +2686,7 @@
 				F453C41E2DF0B43D007EAD5F /* LegacyCatalog.swift in Sources */,
 				F453C41F2DF0B43D007EAD5F /* BlurHashEncode.swift in Sources */,
 				F453C4A02DF1D7C0007EAD5F /* RestoreBackend.swift in Sources */,
+				F4C947D62E0B12D0001ACC91 /* String+AppleOSBuild.swift in Sources */,
 				F453C4202DF0B43D007EAD5F /* SoftwareCatalog.swift in Sources */,
 				F453C4212DF0B43D007EAD5F /* MobileDeviceFramework.swift in Sources */,
 				0196B45329292B2A00614EF1 /* LinuxVirtualMachineConfigurationHelper.swift in Sources */,

--- a/VirtualCore/Source/VirtualCatalog/SoftwareCatalog+DownloadMatching.swift
+++ b/VirtualCore/Source/VirtualCatalog/SoftwareCatalog+DownloadMatching.swift
@@ -1,0 +1,132 @@
+import Foundation
+import BuddyFoundation
+import OSLog
+
+private let matchLogger = Logger(subsystem: VirtualCoreConstants.subsystemName, category: "SoftwareCatalog+DownloadMatching")
+
+public extension URL {
+    private static let virtualBuddySoftwareCatalogDataKey = "codes.rambo.VirtualBuddy.SoftwareCatalogData"
+
+    /// Custom metadata stored by VirtualBuddy as an extended attribute.
+    /// This is used to match restore images with those in a software catalog even if they are
+    /// renamed by the user or moved within the same volume.
+    struct VirtualBuddyCatalogData: Codable, Hashable, Sendable {
+        /// The build number for the OS version represented by the restore image file.
+        public var build: String
+        /// The original name of the corresponding file in the software catalog.
+        public var filename: String
+
+        public init(build: String, filename: String) {
+            self.build = build
+            self.filename = filename
+        }
+
+        public init(_ image: RestoreImage) {
+            self.init(build: image.build, filename: image.url.lastPathComponent)
+        }
+    }
+
+    var vb_softwareCatalogData: VirtualBuddyCatalogData? {
+        get {
+            if let value: VirtualBuddyCatalogData = vb_decodeExtendedAttribute(forKey: Self.virtualBuddySoftwareCatalogDataKey) {
+                value
+            } else if let downloadedFromURL = vb_whereFromsSpotlightMetadata.first,
+                      let build = downloadedFromURL.lastPathComponent.matchAppleOSBuild()
+            {
+                /// The `com.apple.metadata:kMDItemWhereFroms` extended attribute can be used to determine where a file was originally downloaded from.
+                /// If the original download URL had a well-formed OS version build in it, then we can use that attribute even if the file doesn't have the custom VirtualBuddy attribute.
+                VirtualBuddyCatalogData(build: build, filename: downloadedFromURL.lastPathComponent)
+            } else {
+                nil
+            }
+        }
+        nonmutating set {
+            guard let newValue else {
+                try? vb_removeExtendedAttribute(forKey: Self.virtualBuddySoftwareCatalogDataKey)
+                return
+            }
+
+            try? vb_encodeExtendedAttribute(newValue, forKey: Self.virtualBuddySoftwareCatalogDataKey)
+        }
+    }
+}
+
+extension URL {
+    /// Parses a Spotlight attribute that includes the URL that was used to download the file.
+    /// This attribute is added automatically and can be used when matching local files with software catalog contents.
+    var vb_whereFromsSpotlightMetadata: [URL] {
+        guard let data = vb_extendedAttributeData(forKey: "com.apple.metadata:kMDItemWhereFroms", base64: false) else { return [] }
+        guard let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [Any] else { return [] }
+
+        return plist
+            .compactMap { $0 as? String }
+            .compactMap { URL(string: $0) }
+    }
+
+    /// Loads properties that can be used to match a local file URL with a restore image in the software catalog.
+    /// Used when matching user-provided restore image files or previously-downloaded restore images with catalog content.
+    struct RestoreImageStub: Hashable, Sendable, DownloadableCatalogContent, CustomStringConvertible {
+        var id: String { build }
+        var build: String
+        var url: URL
+
+        init(build: String, url: URL) {
+            self.build = build
+            self.url = url
+        }
+
+        init(url: URL) {
+            /// We need some way to determine the OS build corresponding to this file URL.
+            /// This will be first read from the extended attributes set by the app itself when it downloads a software image.
+            /// This metadata will survive file renames and files being moved within the same volume.
+            /// If no metadata can be found, attempt to parse an OS build string from the file name itself.
+            let build = url.vb_softwareCatalogData?.build ?? url.lastPathComponent.matchAppleOSBuild() ?? ""
+
+            self.init(build: build, url: url)
+        }
+
+        var description: String { "\(url.lastPathComponent) (build \(build.isEmpty ? "?" : build))" }
+    }
+
+    /// Container for properties of a restore image that can be inferred from a local file by reading from extended attributes or parsing from the file name.
+    var vb_restoreImageStub: RestoreImageStub { RestoreImageStub(url: self) }
+}
+
+public extension SoftwareCatalog {
+    /// Returns the restore image in the catalog that corresponds to the restore image in the file URL.
+    ///
+    /// This matches local restore images with catalog images by file name, build number, or using extended attributes that
+    /// the app automatically sets on restore images downloaded through the app.
+    func restoreImageMatchingDownloadableCatalogContent(at fileURL: URL) -> RestoreImage? {
+        restoreImages.vb_elementMatchingDownloadableCatalogContent(at: fileURL)
+    }
+}
+
+public extension ResolvedCatalog {
+    func restoreImageMatchingDownloadableCatalogContent(at fileURL: URL) -> ResolvedRestoreImage? {
+        let restoreImages: [ResolvedRestoreImage] = groups.flatMap(\.restoreImages)
+        return restoreImages.vb_elementMatchingDownloadableCatalogContent(at: fileURL)
+    }
+}
+
+extension Array where Element: DownloadableCatalogContent {
+    func vb_elementMatchingDownloadableCatalogContent(at url: URL) -> Element? {
+        if let match = first(where: { $0.url.lastPathComponent.caseInsensitiveCompare(url.lastPathComponent) == .orderedSame }) {
+            matchLogger.debug("Matched by file name: \(url.lastPathComponent.quoted) <> \(match.url.lastPathComponent.quoted)")
+            return match
+        } else if url.isFileURL,
+                  let catalogData = url.vb_softwareCatalogData,
+                  let match = first(where: { $0.build == catalogData.build || $0.url.lastPathComponent.caseInsensitiveCompare(catalogData.filename) == .orderedSame }) {
+            matchLogger.debug("Matched by metadata: \(url.lastPathComponent.quoted) <> \(match.url.lastPathComponent.quoted)")
+            return match
+        } else if let build = url.lastPathComponent.matchAppleOSBuild(),
+                  let match = first(where: { $0.build.caseInsensitiveCompare(build) == .orderedSame })
+        {
+            matchLogger.debug("Matched by build: \(url.lastPathComponent.quoted) <> \(match.url.lastPathComponent.quoted)")
+            return match
+        } else {
+            return nil
+        }
+    }
+}
+

--- a/VirtualCore/Source/VirtualCatalog/SoftwareCatalog.swift
+++ b/VirtualCore/Source/VirtualCatalog/SoftwareCatalog.swift
@@ -127,8 +127,14 @@ public struct CatalogChannel: CatalogModel {
     }
 }
 
+/// Adopted by both ``RestoreImage`` and ``ResolvedRestoreImage`` to make download lookup more convenient to implement.
+public protocol DownloadableCatalogContent: Identifiable, Hashable, Sendable {
+    var build: String { get }
+    var url: URL { get }
+}
+
 /// Defines an individual macOS restore image in the catalog.
-public struct RestoreImage: CatalogModel {
+public struct RestoreImage: CatalogModel, DownloadableCatalogContent {
     /// Unique identifier for this restore image.
     public var id: String
     /// Identifier of the ``CatalogGroup`` this restore image is a part of.

--- a/VirtualCore/Source/VirtualCatalog/Utilities/String+AppleOSBuild.swift
+++ b/VirtualCore/Source/VirtualCatalog/Utilities/String+AppleOSBuild.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension String {
+    static let appleOSBuildRegex = /[0-9]{2}[A-Z][0-9]{2,}[a-z]?/
+
+    /// Returns the first regex match for an Apple OS build number (ex: `23A5276f`).
+    func matchAppleOSBuild() -> String? {
+        (try? Self.appleOSBuildRegex.firstMatch(in: self)?.output).flatMap { String($0) }
+    }
+}

--- a/VirtualCore/Source/VirtualCatalog/Utilities/URL+ExtendedAttributes.swift
+++ b/VirtualCore/Source/VirtualCatalog/Utilities/URL+ExtendedAttributes.swift
@@ -1,0 +1,64 @@
+import Foundation
+import BuddyFoundation
+
+extension URL {
+    func vb_encodeExtendedAttribute<T: Encodable>(_ value: T, forKey key: String) throws {
+        let data = try JSONEncoder.vb_extendedAttribute.encode(value)
+        try vb_setExtendedAttributeData(data, forKey: key)
+    }
+
+    func vb_decodeExtendedAttribute<T: Decodable>(forKey key: String) -> T? {
+        try? vb_extendedAttributeData(forKey: key).flatMap {
+            try JSONDecoder.vb_extendedAttribute.decode(T.self, from: $0)
+        }
+    }
+
+    func vb_setExtendedAttributeData(_ value: Data, forKey key: String, base64: Bool = true) throws {
+        let effectiveValue = base64 ? value.base64EncodedData() : value
+
+        let size = effectiveValue.count
+        let err = effectiveValue.withUnsafeBytes { ptr in
+            setxattr(path, key, ptr.baseAddress, size, 0, 0)
+        }
+
+        guard err == 0 else {
+            throw "setxattr error code \(err)"
+        }
+    }
+
+    func vb_extendedAttributeData(forKey key: String, base64: Bool = true) -> Data? {
+        var size = getxattr(path, key, nil, .max, 0, 0)
+
+        guard size > 0 else {
+            return nil
+        }
+
+        let pointer = UnsafeMutableRawPointer.allocate(byteCount: size, alignment: 2)
+        size = getxattr(path, key, pointer, size, 0, 0)
+
+        guard size > 0 else {
+            pointer.deallocate()
+            return nil
+        }
+
+        let data = Data(bytesNoCopy: pointer, count: size, deallocator: .free)
+
+        guard base64 else { return data }
+
+        return Data(base64Encoded: data)
+    }
+
+    func vb_removeExtendedAttribute(forKey key: String) throws {
+        let err = removexattr(path, key, 0)
+        guard err == 0 else {
+            throw "removexattr error code \(err)"
+        }
+    }
+}
+
+private extension JSONEncoder {
+    static let vb_extendedAttribute = JSONEncoder()
+}
+private extension JSONDecoder {
+    static let vb_extendedAttribute = JSONDecoder()
+}

--- a/VirtualUI/Source/Installer/VMInstallationViewModel.swift
+++ b/VirtualUI/Source/Installer/VMInstallationViewModel.swift
@@ -388,6 +388,13 @@ final class VMInstallationViewModel: ObservableObject, @unchecked Sendable {
         downloader = nil
 
         do {
+            /// Attach metadata to the file so that VirtualBuddy can match it with the restore image in the software catalog
+            /// even if the user renames the file or moves it within the same volume.
+            if data.systemType == .mac, let restoreImage = data.restoreImage {
+                UILog("Attaching metadata for \(restoreImage.name.quoted) to downloaded file \(fileURL.lastPathComponent.quoted)")
+                fileURL.vb_softwareCatalogData = .init(restoreImage)
+            }
+
             try updateModelInstallerURL(with: fileURL)
 
             next()


### PR DESCRIPTION
Add different methods to match local files with remote software catalog contents:

- Direct file name match
- macOS build number regex match
- Spotlight extended attributes
- Custom VirtualBuddy extended attributes

This allows matching of user-provided files with remote catalog content for feature availability checks and other purposes. It also allows users to freely rename downloaded restore images without affecting the app's ability to match catalog content with the locally-downloaded file, as long as downloads are in a volume that supports extended attributes.