### PR TITLE
Make device support update requirement more prominent, improve instructions

### DIFF
--- a/VirtualBuddy.xcodeproj/xcshareddata/xcschemes/VirtualBuddy (Managed).xcscheme
+++ b/VirtualBuddy.xcodeproj/xcshareddata/xcschemes/VirtualBuddy (Managed).xcscheme
@@ -93,7 +93,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-VBSimulateMobileDeviceVersion 1770.0.0"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-VBForceSigningStatusUnsigned YES"

--- a/VirtualBuddy.xcodeproj/xcshareddata/xcschemes/VirtualBuddy (Managed).xcscheme
+++ b/VirtualBuddy.xcodeproj/xcshareddata/xcschemes/VirtualBuddy (Managed).xcscheme
@@ -93,7 +93,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-VBSimulateMobileDeviceVersion 1770.0.0"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-VBForceSigningStatusUnsigned YES"

--- a/VirtualBuddy/CommandLine/vctool/Core/Helpers.swift
+++ b/VirtualBuddy/CommandLine/vctool/Core/Helpers.swift
@@ -114,9 +114,9 @@ extension ResolvedFeatureStatus {
         switch self {
         case .supported:
             return "✅ Supported"
-        case .warning(let message):
+        case .warning(_, let message):
             return "⚠️ Warning: \(message)"
-        case .unsupported(let message):
+        case .unsupported(_, let message):
             return "🛑 Not Supported: \(message)"
         }
     }

--- a/VirtualBuddy/CommandLine/vctool/MigrateCommand.swift
+++ b/VirtualBuddy/CommandLine/vctool/MigrateCommand.swift
@@ -52,7 +52,7 @@ extension CatalogCommand {
             } else {
                 fputs("Creating empty version 2 catalog for migration\n", stderr)
 
-                catalog = SoftwareCatalog(apiVersion: 2, minAppVersion: .init(string: "2.0.0")!, channels: [], groups: [], restoreImages: [], features: [], requirementSets: [])
+                catalog = SoftwareCatalog(apiVersion: 2, minAppVersion: .init(string: "2.0.0")!, channels: [], groups: [], restoreImages: [], features: [], requirementSets: [], deviceSupportVersions: [])
             }
 
             for legacyChannel in legacyCatalog.channels {

--- a/VirtualCore/Source/VirtualCatalog/SoftwareCatalog.swift
+++ b/VirtualCore/Source/VirtualCatalog/SoftwareCatalog.swift
@@ -127,6 +127,19 @@ public struct CatalogChannel: CatalogModel {
     }
 }
 
+/// Describes a "device support files" installation and the instructions that should be presented to the user when it's required.
+public struct CatalogDeviceSupportVersion: CatalogModel {
+    public var id: String
+    /// Hint for which MobileDevice version this entry refers to.
+    public var mobileDeviceMinVersion: SoftwareVersion
+    /// OS version this entry refers to. Matching will be attempted by `major.minor` first, then `major` only.
+    public var osVersion: SoftwareVersion
+    /// User-facing title displayed on the list of software images.
+    public var title: String
+    /// User-facing instructions displayed in interstitial or when user clicks the warning. May contain markdown.
+    public var instructions: String
+}
+
 /// Adopted by both ``RestoreImage`` and ``ResolvedRestoreImage`` to make download lookup more convenient to implement.
 public protocol DownloadableCatalogContent: Identifiable, Hashable, Sendable {
     var build: String { get }
@@ -188,8 +201,10 @@ public struct SoftwareCatalog: Codable, Sendable {
     public var features: [VirtualizationFeature]
     /// Requirement set definitions.
     public var requirementSets: [RequirementSet]
+    /// Device support files definitions.
+    public var deviceSupportVersions: [CatalogDeviceSupportVersion]
 
-    public init(apiVersion: Int, minAppVersion: SoftwareVersion, channels: [CatalogChannel], groups: [CatalogGroup], restoreImages: [RestoreImage], features: [VirtualizationFeature], requirementSets: [RequirementSet]) {
+    public init(apiVersion: Int, minAppVersion: SoftwareVersion, channels: [CatalogChannel], groups: [CatalogGroup], restoreImages: [RestoreImage], features: [VirtualizationFeature], requirementSets: [RequirementSet], deviceSupportVersions: [CatalogDeviceSupportVersion]) {
         self.apiVersion = apiVersion
         self.minAppVersion = minAppVersion
         self.channels = channels
@@ -197,9 +212,10 @@ public struct SoftwareCatalog: Codable, Sendable {
         self.restoreImages = restoreImages
         self.features = features
         self.requirementSets = requirementSets
+        self.deviceSupportVersions = deviceSupportVersions
     }
 
-    public static let empty = SoftwareCatalog(apiVersion: 0, minAppVersion: .empty, channels: [], groups: [], restoreImages: [], features: [], requirementSets: [])
+    public static let empty = SoftwareCatalog(apiVersion: 0, minAppVersion: .empty, channels: [], groups: [], restoreImages: [], features: [], requirementSets: [], deviceSupportVersions: [])
 }
 
 public extension SoftwareCatalog {

--- a/VirtualUI/Source/Installer/Steps/Restore Image Selection/Components/SoftwareCatalog+Placeholder.swift
+++ b/VirtualUI/Source/Installer/Steps/Restore Image Selection/Components/SoftwareCatalog+Placeholder.swift
@@ -68,9 +68,9 @@ extension ResolvedRequirementSet {
 }
 
 extension SoftwareCatalog {
-    static let placeholder = SoftwareCatalog(apiVersion: 1, minAppVersion: "1.0", channels: [.placeholder], groups: [.placeholder], restoreImages: [.placeholder], features: [], requirementSets: [.placeholder])
+    static let placeholder = SoftwareCatalog(apiVersion: 1, minAppVersion: "1.0", channels: [.placeholder], groups: [.placeholder], restoreImages: [.placeholder], features: [], requirementSets: [.placeholder], deviceSupportVersions: [])
 }
 
 extension ResolvedRestoreImage {
-    static let placeholder = ResolvedRestoreImage(image: .placeholder, channel: .placeholder, features: [], requirements: .placeholder, status: .supported, localFileURL: nil)
+    static let placeholder = ResolvedRestoreImage(image: .placeholder, channel: .placeholder, features: [], requirements: .placeholder, status: .supported, localFileURL: nil, deviceSupportVersion: nil)
 }

--- a/data/ipsws_v2.json
+++ b/data/ipsws_v2.json
@@ -208,6 +208,15 @@
       "minVersionHost" : "13.0.0"
     }
   ],
+    "deviceSupportVersions": [
+        {
+            "id": "device_support_macOS26_beta",
+            "mobileDeviceMinVersion": "1810.0.0",
+            "osVersion": "26.0.0",
+            "title": "Device Support Update Required",
+            "instructions": "Your Mac needs an update to install virtual machines that use this version of macOS.\n\nHere’s how you can install the update:\n\n1. Head over to the [Apple Developer downloads page](https://developer.apple.com/download/).\n2. Under “Operating Systems”, find “Device Support for macOS 26”.\n3. Click the link below that item.\n4. Double-click the downloaded DMG and open the installer. Follow the instructions.\n5. Quit and relaunch VirtualBuddy. Then, try again.\n\nInstalling the latest Xcode beta will also install the required update."
+        }
+    ],
   "restoreImages" : [
     {
       "build" : "25A5295e",


### PR DESCRIPTION
- Adds a new `deviceSupportVersions` entry to catalog that can be used to provide better instructions to users about installing the required device support package for a given macOS release
- Makes the mobile device min version check an `.unsupported` status rather than `.warning`
- Increases prominence of unsupported warning in restore images browser UI

![CleanShot 2025-06-24 at 17 26 08](https://github.com/user-attachments/assets/886385bf-deb3-4e64-8877-f066c758581d)
