### PR TITLE
Fix Linux v2 catalog

### DIFF
--- a/data/linux_v2.json
+++ b/data/linux_v2.json
@@ -65,6 +65,8 @@
       "unsupportedPlatform" : false
     }
   ],
+    "deviceSupportVersions": [
+    ],
   "groups" : [
     {
       "darkImage" : {


### PR DESCRIPTION
It was missing a new key added to support the latest 2.1 build.