### PR TITLE
Respect sorting from catalog when listing OS versions for download/installation

### DIFF
--- a/VirtualUI/Source/Installer/Steps/Restore Image Selection/Components/RestoreImageBrowser.swift
+++ b/VirtualUI/Source/Installer/Steps/Restore Image Selection/Components/RestoreImageBrowser.swift
@@ -12,6 +12,7 @@ import BuddyKit
 
 struct ChannelGroup: Identifiable, Hashable {
     var id: CatalogChannel.ID { channel.id }
+    var order: Int
     var channel: CatalogChannel
     var images: [ResolvedRestoreImage]
 }

--- a/VirtualUI/Source/Installer/Steps/Restore Image Selection/RestoreImageSelectionController.swift
+++ b/VirtualUI/Source/Installer/Steps/Restore Image Selection/RestoreImageSelectionController.swift
@@ -162,16 +162,17 @@ extension ChannelGroup {
     static func groups(with restoreImages: [ResolvedRestoreImage]) -> [ChannelGroup] {
         var groupsByChannel = [CatalogChannel: ChannelGroup]()
 
-        let sortedImages = restoreImages.sorted(by: { $0.build > $1.build })
+        for image in restoreImages {
+            /// Ensures images from each group are listed in the same order as the groups are ordered in the catalog.
+            let order = groupsByChannel.keys.count
 
-        for image in sortedImages {
-            groupsByChannel[image.channel, default: ChannelGroup(channel: image.channel, images: [])]
-                .images.append(image)
+            groupsByChannel[image.channel, default: ChannelGroup(
+                order: order,
+                channel: image.channel,
+                images: []
+            )].images.append(image)
         }
 
-        /// Place regular releases above developer betas.
-        return groupsByChannel.values.sorted {
-            $0.id == "regular" && $1.id == "devbeta"
-        }
+        return groupsByChannel.values.sorted(by: { $0.order < $1.order })
     }
 }


### PR DESCRIPTION
Instead of attempting to sort by build and channel — which only worked correctly for macOS — respect the sorting from the catalog JSON files.

OS versions for download/installation are listed in the same order as they appear in the catalog, and grouping by channel also respects the order of the `channels` array in the catalog.