### PR TITLE
Improve error handling for failed download/install

### DIFF
--- a/VirtualCore/Source/Restore/Installation/VirtualizationRestoreBackend.swift
+++ b/VirtualCore/Source/Restore/Installation/VirtualizationRestoreBackend.swift
@@ -53,6 +53,8 @@ public final class VirtualizationRestoreBackend: RestoreBackend {
     public func cancel() async {
         logger.warning("Installation cancelled by client.")
 
+        progress.cancel()
+
         if let _installer, _installer.virtualMachine.canStop {
             do {
                 logger.info("Stopping installation VM...")

--- a/VirtualUI/Source/Installer/VMInstallData.swift
+++ b/VirtualUI/Source/Installer/VMInstallData.swift
@@ -179,7 +179,8 @@ extension VMInstallData {
         case .remoteManual, .remoteOptions:
             /// `localRestoreImageURL` is set when user selects a remote URL but that file has already been downloaded to the local library.
             /// Check that the file name matches and skip download when that's the case.
-            if let localRestoreImageURL, localRestoreImageURL.lastPathComponent == downloadURL.lastPathComponent {
+            /// Also ensure the local file actually exists, as it could have been deleted before the setup process read this property.
+            if let localRestoreImageURL, localRestoreImageURL.lastPathComponent == downloadURL.lastPathComponent, FileManager.default.fileExists(atPath: localRestoreImageURL.path) {
                 UILog("[\(#function)] Method is \(installMethod), remote URL is \(downloadURL.absoluteString.quoted), found matching download at \(localRestoreImageURL.path.quoted).")
 
                 return false
@@ -189,6 +190,14 @@ extension VMInstallData {
                 return true
             }
         }
+    }
+
+    @MainActor
+    mutating func resetRestoreImageSelection() {
+        installMethodSelection = nil
+        resolvedRestoreImage = nil
+        localRestoreImageURL = nil
+        restoreImage = nil
     }
 }
 


### PR DESCRIPTION
- When download fails due to an HTTP error, report this in the UI and DO NOT save the downloaded response
- When installation fails due to a corrupt disk image, report this in the UI
- For both of the above cases, allow going back in the setup process to change settings and try again

<img src="https://github.com/user-attachments/assets/3dc676d7-5bf6-4293-a297-8817da471d61" width="380">
<img src="https://github.com/user-attachments/assets/009b7697-4d60-4107-a6e0-a4a8dad8adc7" width="380">
