### PR TITLE
Skip validating new virtual machine name if not changed

### DIFF
--- a/VirtualCore/Source/Virtualization/VMLibraryController.swift
+++ b/VirtualCore/Source/Virtualization/VMLibraryController.swift
@@ -236,6 +236,9 @@ public final class VMLibraryController: ObservableObject {
     }
 
     public func validateNewName(_ name: String, for vm: VBVirtualMachine) throws {
+        /// No need to validate if name is not changed.
+        guard name != vm.name else { return }
+
         try urlForRenaming(vm, to: name)
     }
 


### PR DESCRIPTION
Fixes a bug where pressing return with the virtual machine name field focused would trigger a shaking error animation even if the name had not been changed. The error animation occurred because validation was failing due to "another VM" already existing with the same name.