### PR TITLE
Add launch action to VM installer completion screen

### DIFF
--- a/VirtualUI/Source/Installer/Steps/InstallProgressDoneView.swift
+++ b/VirtualUI/Source/Installer/Steps/InstallProgressDoneView.swift
@@ -1,0 +1,70 @@
+//
+//  InstallProgressDoneView.swift
+//  VirtualBuddy
+//
+//  Created by Michael Fey on 3/10/26.
+//
+
+
+import SwiftUI
+import VirtualCore
+import BuddyKit
+
+struct InstallProgressDoneView: View {
+    @EnvironmentObject private var viewModel: VMInstallationViewModel
+    @EnvironmentObject private var library: VMLibraryController
+    @EnvironmentObject private var sessionManager: VirtualMachineSessionUIManager
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 0)
+
+            VStack(spacing: 18) {
+                VirtualBuddyMonoIcon(style: .success)
+
+                Text(viewModel.data.systemType.installFinishedMessage)
+                    .font(.subheadline)
+
+                if let machine = viewModel.machine {
+                    launchButton(for: machine)
+                        .padding(.top, 10)
+                        .padding(.bottom, 6)
+                }
+            }
+            .monospacedDigit()
+            .multilineTextAlignment(.center)
+            .foregroundStyle(.green)
+            .tint(.green)
+
+            Spacer(minLength: 56)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func launchButton(for machine: VBVirtualMachine) -> some View {
+        ZStack {
+            Button("Let\u{2019}s Go!") {
+                launch(machine)
+            }
+            .foregroundStyle(Color(white: 0.03))
+            .controlSize(.large)
+            .accessibilityHint("Launches the new virtual machine")
+
+            // This is a hidden button that exists purely to accept the keyboardShortcut(.defaultAction) for this window. Setting a default action for a button overrides the foreground styling on the button leaving white text on a lighter green background, which is difficult to read.
+            Button("") {
+                launch(machine)
+            }
+            .keyboardShortcut(.defaultAction)
+            .labelsHidden()
+            .frame(width: 0, height: 0)
+            .opacity(0)
+            .accessibilityHidden(true)
+        }
+    }
+
+    private func launch(_ machine: VBVirtualMachine) {
+        sessionManager.launch(machine, library: library, options: nil)
+        dismiss()
+    }
+}

--- a/VirtualUI/Source/Installer/Steps/Restore Image Selection/Components/InstallProgressDisplayView.swift
+++ b/VirtualUI/Source/Installer/Steps/Restore Image Selection/Components/InstallProgressDisplayView.swift
@@ -4,6 +4,9 @@ import BuddyKit
 
 struct InstallProgressDisplayView: View {
     @EnvironmentObject private var viewModel: VMInstallationViewModel
+    @EnvironmentObject private var library: VMLibraryController
+    @EnvironmentObject private var sessionManager: VirtualMachineSessionUIManager
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         VirtualDisplayView {
@@ -14,10 +17,7 @@ struct InstallProgressDisplayView: View {
                 case .install:
                     InstallProgressStepView()
                 case .done:
-                    VirtualBuddyMonoProgressView(
-                        status: Text(viewModel.data.systemType.installFinishedMessage),
-                        style: .success
-                    )
+                    InstallProgressDoneView()
                 default:
                     EmptyView()
                 }

--- a/VirtualUI/Source/Installer/VMInstallationWizard.swift
+++ b/VirtualUI/Source/Installer/VMInstallationWizard.swift
@@ -106,7 +106,6 @@ public struct VMInstallationWizard: View {
                     Button("Done") {
                         closeWindow()
                     }
-                    .keyboardShortcut(.defaultAction)
                 }
             }
 
@@ -299,6 +298,8 @@ extension VMInstallationWizard {
     static func preview(step: VMInstallationStep) -> some View {
         VMInstallationWizard(library: .preview, initialStep: step)
             .frame(width: 900)
+            .environmentObject(VMLibraryController.preview)
+            .environmentObject(VirtualMachineSessionUIManager.shared)
     }
 
     @ViewBuilder

--- a/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
@@ -89,6 +89,7 @@ public final class VirtualMachineSessionUIManager: ObservableObject {
         openWindow(animationBehavior: .documentWindow) {
             VMInstallationWizard(library: library, restoringAt: restoreURL)
                 .environmentObject(library)
+                .environmentObject(self)
         }
     }
 


### PR DESCRIPTION
## 🦾 Reason to Be

This MR updates the installer completion screen so finishing a VM setup leaves the user with an actionable next step. The `.done` step now shows a dedicated completion view with a primary `Let’s Go!` action that launches the newly created virtual machine and dismisses the installer window.

It also wires `VirtualMachineSessionUIManager` into the installer launch path and wizard previews so the completion screen has the session-launch dependency it needs.

<img width="1012" height="764" alt="image" src="https://github.com/user-attachments/assets/4bb610a9-90c4-4fbd-84e6-3ff5d0e26b66" />


## 🤔 Thought Process

Built with help from Codex.

The completion state originally used a generic success progress view, which was fine for status display but not for the new launch action and layout requirements. I split the `.done` state into its own `InstallProgressDoneView` so the completion UI could be structured independently without complicating the main progress display switch.

From there, I added a visible `Let’s Go!` button for the primary action and kept the Return key behavior by using a hidden default-action button. That avoids macOS overriding the visible button’s styling when `.keyboardShortcut(.defaultAction)` is applied directly.

I also removed the default-action shortcut from the toolbar `Done` button so Return triggers launch instead of close, and updated the installer launch wiring so the new completion view can access `VirtualMachineSessionUIManager` through the environment.

## 📋 How To Test

1. Launch the installer flow and complete a VM installation until the setup reaches the finished screen.
2. Verify the `.done` screen shows the dedicated completion UI with the success icon, finished message, and `Let’s Go!` button.
3. Click `Let’s Go!` and verify the new VM launches and the installer window closes.
4. Press Return on the completion screen and verify it triggers the same launch behavior.
5. Click the toolbar `Done` button and verify it closes the installer without launching the VM.
6. Open installer previews and verify the completion preview still renders correctly with the required environment objects.

## 🐛 Possible Impacts

The main risk area is installer window/environment wiring. The completion screen now depends on `VirtualMachineSessionUIManager` being injected anywhere `VMInstallationWizard` is presented, so any code path that opens the installer without that environment object could break or fail to launch the VM from the done state.

There is also some behavioral risk around keyboard handling on the completion screen, since Return is now intentionally routed to launch rather than to the toolbar `Done` action.
