### PR TITLE
fix: use cached disk mode for macOS guests to prevent APFS corruption

### DIFF
--- a/VirtualCore/Source/Virtualization/Helpers/VirtualMachineConfigurationHelper.swift
+++ b/VirtualCore/Source/Virtualization/Helpers/VirtualMachineConfigurationHelper.swift
@@ -32,7 +32,9 @@ func createVZDiskImageStorageDeviceAttachment(url: URL, readOnly: Bool, guestTyp
         // fixes this IO errors and disk corruption issues for Linux guest.
         return try VZDiskImageStorageDeviceAttachment(url: url, readOnly: readOnly, cachingMode: .cached, synchronizationMode: .fsync)
     } else {
-        return try VZDiskImageStorageDeviceAttachment(url: url, readOnly: readOnly)
+        // macOS guests also need cached mode to prevent APFS corruption under heavy I/O.
+        // See: UTM #4840, Lima VM #1957
+        return try VZDiskImageStorageDeviceAttachment(url: url, readOnly: readOnly, cachingMode: .cached, synchronizationMode: .fsync)
     }
 }
 


### PR DESCRIPTION
## Summary

Apply `.cached` + `.fsync` disk caching mode to macOS guests, matching the fix already applied to Linux guests in PR #332.

## Problem

macOS guest VMs experience APFS filesystem corruption under heavy I/O because `VZDiskImageStorageDeviceAttachment` uses the default `cachingMode: .automatic` (effectively uncached). After sustained I/O (compilation, large git operations, concurrent writes), the APFS space manager becomes corrupted:

```
warning: spaceman chunk 507 free count 1048012 > block count 32768
error: (oid 0x765b) cib: found zeroed-out block
error: failed to read spaceman cib 7 at address 0x765b
Space manager is invalid.
```

This causes every subsequent `write()` syscall to fail with `EILSEQ` (errno 92), making the VM completely unable to write files. `fsck_apfs -y` cannot repair the damage.

## Fix

Changed the `else` branch in `createVZDiskImageStorageDeviceAttachment` to use `cachingMode: .cached, synchronizationMode: .fsync` for macOS guests, identical to the Linux guest fix.

## Related

- PR #332 -- Fixed this exact issue for Linux guests
- UTM PR #5919 -- Fixed the same Virtualization.framework caching bug
- Lima VM #1957 -- Documents filesystem corruption during heavy I/O in Virtualization.framework VMs
