### PR TITLE
Improve MAC address handling

### DIFF
--- a/VirtualCore/Source/Virtualization/VMController.swift
+++ b/VirtualCore/Source/Virtualization/VMController.swift
@@ -164,22 +164,8 @@ public final class VMController: ObservableObject {
     }
 
     public func start() async throws {
-        // Check for MAC-address collisions with running VMs before changing state.
-        if let handler = macAddressConflictHandler {
-            let conflicts = library.macAddressConflicts(for: virtualMachineModel)
-            if !conflicts.isEmpty {
-                switch await handler(conflicts) {
-                case .cancel:
-                    return
-                case .continueAnyway:
-                    break
-                case .randomize:
-                    for index in virtualMachineModel.configuration.hardware.networkDevices.indices {
-                        virtualMachineModel.configuration.hardware.networkDevices[index].macAddress = VZMACAddress.randomLocallyAdministered().string.uppercased()
-                    }
-                }
-            }
-        }
+        // Check for MAC address collisions with running VMs before changing state.
+        guard await resolveMACAddressConflictsIfNeeded() else { return }
 
         state = .starting(nil)
 
@@ -212,6 +198,29 @@ public final class VMController: ObservableObject {
 
             state = .running(vm)
             virtualMachineModel.metadata.installFinished = true
+        }
+    }
+
+    /// Checks whether this virtual machine's network devices share a MAC address with any running virtual machine,
+    /// asking the conflict handler how to proceed if so.
+    ///
+    /// - Returns: `true` if startup should continue, or `false` if the user chose to cancel the launch.
+    private func resolveMACAddressConflictsIfNeeded() async -> Bool {
+        guard let handler = macAddressConflictHandler else { return true }
+
+        let conflicts = library.macAddressConflicts(for: virtualMachineModel)
+        guard !conflicts.isEmpty else { return true }
+
+        switch await handler(conflicts) {
+        case .cancel:
+            return false
+        case .continueAnyway:
+            return true
+        case .randomize:
+            for index in virtualMachineModel.configuration.hardware.networkDevices.indices {
+                virtualMachineModel.configuration.hardware.networkDevices[index].macAddress = VZMACAddress.randomLocallyAdministered().string.uppercased()
+            }
+            return true
         }
     }
 

--- a/VirtualCore/Source/Virtualization/VMController.swift
+++ b/VirtualCore/Source/Virtualization/VMController.swift
@@ -99,7 +99,6 @@ public final class VMController: ObservableObject {
     public private(set) var state = State.idle
 
     /// Called from ``start()`` when the VM's MAC address collides with a currently-running VM.
-    /// Set by the UI layer to present a prompt. If `nil`, ``start()`` proceeds without checking.
     public var macAddressConflictHandler: (@MainActor ([MACAddressConflict]) async -> MACAddressConflictResolution)?
     
     private(set) var virtualMachine: VZVirtualMachine?

--- a/VirtualCore/Source/Virtualization/VMController.swift
+++ b/VirtualCore/Source/Virtualization/VMController.swift
@@ -101,7 +101,7 @@ public final class VMController: ObservableObject {
 
     /// Called from ``start()`` when the VM's MAC addresses collide with a currently-running VM.
     /// Set by the UI layer to present a prompt. If `nil`, ``start()`` proceeds without checking.
-    public var macAddressConflictHandler: (@MainActor (Set<String>) async -> MACAddressConflictResolution)?
+    public var macAddressConflictHandler: (@MainActor ([MACAddressConflict]) async -> MACAddressConflictResolution)?
     
     private(set) var virtualMachine: VZVirtualMachine?
 

--- a/VirtualCore/Source/Virtualization/VMController.swift
+++ b/VirtualCore/Source/Virtualization/VMController.swift
@@ -88,9 +88,20 @@ public final class VMController: ObservableObject {
     }
     
     public typealias State = VMState
-    
+
     @Published
     public private(set) var state = State.idle
+
+    /// Resolution returned from ``macAddressConflictHandler`` when a duplicate MAC is detected at start time.
+    public enum MACAddressConflictResolution {
+        case cancel
+        case continueAnyway
+        case randomize
+    }
+
+    /// Called from ``start()`` when the VM's MAC addresses collide with a currently-running VM.
+    /// Set by the UI layer to present a prompt. If `nil`, ``start()`` proceeds without checking.
+    public var macAddressConflictHandler: (@MainActor (Set<String>) async -> MACAddressConflictResolution)?
     
     private(set) var virtualMachine: VZVirtualMachine?
 
@@ -155,6 +166,24 @@ public final class VMController: ObservableObject {
     }
 
     public func start() async throws {
+        // Check for MAC-address collisions with running VMs before changing state.
+        // Done here so every start path (autoBoot, in-window button, toolbar) is gated.
+        if let handler = macAddressConflictHandler {
+            let conflicts = library.macAddressConflicts(for: virtualMachineModel)
+            if !conflicts.isEmpty {
+                switch await handler(conflicts) {
+                case .cancel:
+                    return
+                case .continueAnyway:
+                    break
+                case .randomize:
+                    for index in virtualMachineModel.configuration.hardware.networkDevices.indices {
+                        virtualMachineModel.configuration.hardware.networkDevices[index].macAddress = VZMACAddress.randomLocallyAdministered().string.uppercased()
+                    }
+                }
+            }
+        }
+
         state = .starting(nil)
 
         await waitForGuestDiskImageReadyIfNeeded()

--- a/VirtualCore/Source/Virtualization/VMController.swift
+++ b/VirtualCore/Source/Virtualization/VMController.swift
@@ -70,6 +70,12 @@ public enum VMState: Equatable {
     case stopped(Error?)
 }
 
+public enum MACAddressConflictResolution {
+    case cancel
+    case continueAnyway
+    case randomize
+}
+
 @MainActor
 public final class VMController: ObservableObject {
 
@@ -92,14 +98,7 @@ public final class VMController: ObservableObject {
     @Published
     public private(set) var state = State.idle
 
-    /// Resolution returned from ``macAddressConflictHandler`` when a duplicate MAC is detected at start time.
-    public enum MACAddressConflictResolution {
-        case cancel
-        case continueAnyway
-        case randomize
-    }
-
-    /// Called from ``start()`` when the VM's MAC addresses collide with a currently-running VM.
+    /// Called from ``start()`` when the VM's MAC address collides with a currently-running VM.
     /// Set by the UI layer to present a prompt. If `nil`, ``start()`` proceeds without checking.
     public var macAddressConflictHandler: (@MainActor ([MACAddressConflict]) async -> MACAddressConflictResolution)?
     
@@ -167,7 +166,6 @@ public final class VMController: ObservableObject {
 
     public func start() async throws {
         // Check for MAC-address collisions with running VMs before changing state.
-        // Done here so every start path (autoBoot, in-window button, toolbar) is gated.
         if let handler = macAddressConflictHandler {
             let conflicts = library.macAddressConflicts(for: virtualMachineModel)
             if !conflicts.isEmpty {

--- a/VirtualCore/Source/Virtualization/VMLibraryController.swift
+++ b/VirtualCore/Source/Virtualization/VMLibraryController.swift
@@ -383,10 +383,11 @@ public extension VMLibraryController {
         virtualMachines(matching: { $0.name.caseInsensitiveCompare(name) == .orderedSame }).first
     }
 
-    /// Returns MAC addresses from `vm`'s configured network devices that are already in use
-    /// by another VM currently booted in this library. Comparison is case-insensitive and
+    /// Returns the MAC-address conflicts between `vm`'s configured network devices and any
+    /// network device on a VM currently booted in this library. Each entry pairs the offending
+    /// MAC with the name of the running VM that holds it. Comparison is case-insensitive and
     /// ignores empty MACs (e.g. disabled interfaces).
-    func macAddressConflicts(for vm: VBVirtualMachine) -> Set<String> {
+    func macAddressConflicts(for vm: VBVirtualMachine) -> [MACAddressConflict] {
         let candidates = Set(
             vm.configuration.hardware.networkDevices
                 .map { $0.macAddress.uppercased() }
@@ -394,16 +395,28 @@ public extension VMLibraryController {
         )
         guard !candidates.isEmpty else { return [] }
 
-        var runningMACs = Set<String>()
+        var conflicts: [MACAddressConflict] = []
         for runningID in bootedMachineIdentifiers where runningID != vm.id {
             guard let runningVM = virtualMachines.first(where: { $0.id == runningID }) else { continue }
             for device in runningVM.configuration.hardware.networkDevices {
                 let mac = device.macAddress.uppercased()
-                if !mac.isEmpty { runningMACs.insert(mac) }
+                guard candidates.contains(mac) else { continue }
+                conflicts.append(MACAddressConflict(macAddress: mac, runningVMName: runningVM.name))
             }
         }
+        return conflicts
+    }
+}
 
-        return candidates.intersection(runningMACs)
+/// A single MAC-address conflict detected by ``VMLibraryController/macAddressConflicts(for:)``,
+/// pairing the duplicated MAC with the name of the running VM that already holds it.
+public struct MACAddressConflict: Hashable {
+    public let macAddress: String
+    public let runningVMName: String
+
+    public init(macAddress: String, runningVMName: String) {
+        self.macAddress = macAddress
+        self.runningVMName = runningVMName
     }
 }
 

--- a/VirtualCore/Source/Virtualization/VMLibraryController.swift
+++ b/VirtualCore/Source/Virtualization/VMLibraryController.swift
@@ -374,6 +374,16 @@ public final class VMLibraryController: ObservableObject {
 
 // MARK: - Queries
 
+public struct MACAddressConflict: Hashable {
+    public let macAddress: String
+    public let vmName: String
+
+    public init(macAddress: String, runningVMName: String) {
+        self.macAddress = macAddress
+        self.vmName = runningVMName
+    }
+}
+
 public extension VMLibraryController {
     func virtualMachines(matching predicate: (VBVirtualMachine) -> Bool) -> [VBVirtualMachine] {
         virtualMachines.filter(predicate)
@@ -401,16 +411,6 @@ public extension VMLibraryController {
             }
         }
         return conflicts
-    }
-}
-
-public struct MACAddressConflict: Hashable {
-    public let macAddress: String
-    public let vmName: String
-
-    public init(macAddress: String, runningVMName: String) {
-        self.macAddress = macAddress
-        self.vmName = runningVMName
     }
 }
 

--- a/VirtualCore/Source/Virtualization/VMLibraryController.swift
+++ b/VirtualCore/Source/Virtualization/VMLibraryController.swift
@@ -383,10 +383,6 @@ public extension VMLibraryController {
         virtualMachines(matching: { $0.name.caseInsensitiveCompare(name) == .orderedSame }).first
     }
 
-    /// Returns the MAC-address conflicts between `vm`'s configured network devices and any
-    /// network device on a VM currently booted in this library. Each entry pairs the offending
-    /// MAC with the name of the running VM that holds it. Comparison is case-insensitive and
-    /// ignores empty MACs (e.g. disabled interfaces).
     func macAddressConflicts(for vm: VBVirtualMachine) -> [MACAddressConflict] {
         let candidates = Set(
             vm.configuration.hardware.networkDevices
@@ -408,15 +404,13 @@ public extension VMLibraryController {
     }
 }
 
-/// A single MAC-address conflict detected by ``VMLibraryController/macAddressConflicts(for:)``,
-/// pairing the duplicated MAC with the name of the running VM that already holds it.
 public struct MACAddressConflict: Hashable {
     public let macAddress: String
-    public let runningVMName: String
+    public let vmName: String
 
     public init(macAddress: String, runningVMName: String) {
         self.macAddress = macAddress
-        self.runningVMName = runningVMName
+        self.vmName = runningVMName
     }
 }
 

--- a/VirtualCore/Source/Virtualization/VMLibraryController.swift
+++ b/VirtualCore/Source/Virtualization/VMLibraryController.swift
@@ -382,6 +382,29 @@ public extension VMLibraryController {
     func virtualMachine(named name: String) -> VBVirtualMachine? {
         virtualMachines(matching: { $0.name.caseInsensitiveCompare(name) == .orderedSame }).first
     }
+
+    /// Returns MAC addresses from `vm`'s configured network devices that are already in use
+    /// by another VM currently booted in this library. Comparison is case-insensitive and
+    /// ignores empty MACs (e.g. disabled interfaces).
+    func macAddressConflicts(for vm: VBVirtualMachine) -> Set<String> {
+        let candidates = Set(
+            vm.configuration.hardware.networkDevices
+                .map { $0.macAddress.uppercased() }
+                .filter { !$0.isEmpty }
+        )
+        guard !candidates.isEmpty else { return [] }
+
+        var runningMACs = Set<String>()
+        for runningID in bootedMachineIdentifiers where runningID != vm.id {
+            guard let runningVM = virtualMachines.first(where: { $0.id == runningID }) else { continue }
+            for device in runningVM.configuration.hardware.networkDevices {
+                let mac = device.macAddress.uppercased()
+                if !mac.isEmpty { runningMACs.insert(mac) }
+            }
+        }
+
+        return candidates.intersection(runningMACs)
+    }
 }
 
 // MARK: - Management Actions

--- a/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
@@ -38,23 +38,32 @@ public final class VirtualMachineSessionUIManager: ObservableObject {
         if let existingSession = session(for: vm) {
             existingSession.update(with: options)
             existingSession.bringToFront()
-            return
-        }
-
-        let conflicts = findMACAddressConflicts(for: vm, in: library)
-        guard !conflicts.isEmpty else {
+        } else {
             launchNewSession(for: vm, library: library, options: options)
-            return
+        }
+    }
+
+    /// Runs the MAC-address conflict check against currently-running VMs, prompts the user
+    /// if there's a collision, optionally randomizes the MACs, then starts the VM.
+    /// Resume is intentionally not routed through here — a paused VM is already using its MAC.
+    public func startVM(controller: VMController, library: VMLibraryController) async {
+        let conflicts = findMACAddressConflicts(for: controller.virtualMachineModel, in: library)
+
+        if !conflicts.isEmpty {
+            switch await presentMACAddressConflictAlert(conflicts: conflicts) {
+            case .cancel:
+                return
+            case .continueAnyway:
+                break
+            case .randomize:
+                for index in controller.virtualMachineModel.configuration.hardware.networkDevices.indices {
+                    controller.virtualMachineModel.configuration.hardware.networkDevices[index].macAddress = VZMACAddress.randomLocallyAdministered().string.uppercased()
+                }
+                // VMController's $virtualMachineModel sink persists the change via saveMetadata.
+            }
         }
 
-        Task {
-            await resolveMACAddressConflictsAndLaunch(
-                vm: vm,
-                conflicts: conflicts,
-                library: library,
-                options: options
-            )
-        }
+        try? await controller.start()
     }
 
     private enum MACAddressConflictResolution {
@@ -81,34 +90,6 @@ public final class VirtualMachineSessionUIManager: ObservableObject {
         }
 
         return candidates.intersection(runningMACs)
-    }
-
-    private func resolveMACAddressConflictsAndLaunch(
-        vm: VBVirtualMachine,
-        conflicts: Set<String>,
-        library: VMLibraryController,
-        options: VMSessionOptions?
-    ) async {
-        switch await presentMACAddressConflictAlert(conflicts: conflicts) {
-        case .cancel:
-            return
-        case .continueAnyway:
-            launchNewSession(for: vm, library: library, options: options)
-        case .randomize:
-            var updatedVM = vm
-            for index in updatedVM.configuration.hardware.networkDevices.indices {
-                updatedVM.configuration.hardware.networkDevices[index].macAddress = VZMACAddress.randomLocallyAdministered().string.uppercased()
-            }
-            do {
-                try updatedVM.saveMetadata()
-                library.reload()
-            } catch {
-                logger.error("Failed to save randomized MAC addresses for \(updatedVM.name, privacy: .public): \(error, privacy: .public)")
-                NSAlert(error: error).runModal()
-                return
-            }
-            launchNewSession(for: updatedVM, library: library, options: options)
-        }
     }
 
     private func presentMACAddressConflictAlert(conflicts: Set<String>) async -> MACAddressConflictResolution {

--- a/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
@@ -49,7 +49,7 @@ public final class VirtualMachineSessionUIManager: ObservableObject {
             .sorted { $0.macAddress < $1.macAddress }
             .map { "\($0.macAddress) used by \"\($0.vmName)\"" }
             .joined(separator: "\n")
-        alert.informativeText = "A network device on this VM shares a MAC address with a virtual machine that's already running:\n\n\(formattedConflicts)\n\nRunning multiple virtual machines with the same MAC address on the same network may cause connectivity issues."
+        alert.informativeText = "A network device on this virtual machine shares a MAC address with another virtual machine that's already running:\n\n\(formattedConflicts)\n\nRunning multiple virtual machines with the same MAC address may cause network connectivity issues."
         alert.addButton(withTitle: "Randomize MAC address & Continue")
         alert.addButton(withTitle: "Continue Anyway")
         alert.addButton(withTitle: "Cancel")

--- a/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
@@ -42,14 +42,14 @@ public final class VirtualMachineSessionUIManager: ObservableObject {
         }
     }
 
-    private func presentMACAddressConflictAlert(conflicts: [MACAddressConflict]) async -> VMController.MACAddressConflictResolution {
+    private func presentMACAddressConflictAlert(conflicts: [MACAddressConflict]) async -> MACAddressConflictResolution {
         let alert = NSAlert()
         alert.messageText = "Duplicate MAC Address"
         let formattedConflicts = conflicts
             .sorted { $0.macAddress < $1.macAddress }
-            .map { "\($0.macAddress) — in use by \"\($0.runningVMName)\"" }
+            .map { "\($0.macAddress) used by \"\($0.vmName)\"" }
             .joined(separator: "\n")
-        alert.informativeText = "A network device on this virtual machine shares a MAC address with a virtual machine that's already running:\n\n\(formattedConflicts)\n\nRunning multiple virtual machines with the same MAC address on the same network may cause connectivity issues."
+        alert.informativeText = "A network device on this VM shares a MAC address with a virtual machine that's already running:\n\n\(formattedConflicts)\n\nRunning multiple virtual machines with the same MAC address on the same network may cause connectivity issues."
         alert.addButton(withTitle: "Randomize MAC address & Continue")
         alert.addButton(withTitle: "Continue Anyway")
         alert.addButton(withTitle: "Cancel")

--- a/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
@@ -42,12 +42,15 @@ public final class VirtualMachineSessionUIManager: ObservableObject {
         }
     }
 
-    private func presentMACAddressConflictAlert(conflicts: Set<String>) async -> VMController.MACAddressConflictResolution {
+    private func presentMACAddressConflictAlert(conflicts: [MACAddressConflict]) async -> VMController.MACAddressConflictResolution {
         let alert = NSAlert()
         alert.messageText = "Duplicate MAC Address"
-        let formattedConflicts = conflicts.sorted().joined(separator: ", ")
-        alert.informativeText = "One or more network devices on this virtual machine share a MAC address with a virtual machine that's already running:\n\n\(formattedConflicts)\n\nRunning multiple virtual machines with the same MAC address on the same network may cause connectivity issues."
-        alert.addButton(withTitle: "Randomize MAC address(es) & Continue")
+        let formattedConflicts = conflicts
+            .sorted { $0.macAddress < $1.macAddress }
+            .map { "\($0.macAddress) — in use by \"\($0.runningVMName)\"" }
+            .joined(separator: "\n")
+        alert.informativeText = "A network device on this virtual machine shares a MAC address with a virtual machine that's already running:\n\n\(formattedConflicts)\n\nRunning multiple virtual machines with the same MAC address on the same network may cause connectivity issues."
+        alert.addButton(withTitle: "Randomize MAC address & Continue")
         alert.addButton(withTitle: "Continue Anyway")
         alert.addButton(withTitle: "Cancel")
 

--- a/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import Virtualization
 import VirtualCore
 import Combine
 import OSLog
@@ -43,61 +42,12 @@ public final class VirtualMachineSessionUIManager: ObservableObject {
         }
     }
 
-    /// Runs the MAC-address conflict check against currently-running VMs, prompts the user
-    /// if there's a collision, optionally randomizes the MACs, then starts the VM.
-    /// Resume is intentionally not routed through here — a paused VM is already using its MAC.
-    public func startVM(controller: VMController, library: VMLibraryController) async {
-        let conflicts = findMACAddressConflicts(for: controller.virtualMachineModel, in: library)
-
-        if !conflicts.isEmpty {
-            switch await presentMACAddressConflictAlert(conflicts: conflicts) {
-            case .cancel:
-                return
-            case .continueAnyway:
-                break
-            case .randomize:
-                for index in controller.virtualMachineModel.configuration.hardware.networkDevices.indices {
-                    controller.virtualMachineModel.configuration.hardware.networkDevices[index].macAddress = VZMACAddress.randomLocallyAdministered().string.uppercased()
-                }
-                // VMController's $virtualMachineModel sink persists the change via saveMetadata.
-            }
-        }
-
-        try? await controller.start()
-    }
-
-    private enum MACAddressConflictResolution {
-        case cancel
-        case continueAnyway
-        case randomize
-    }
-
-    private func findMACAddressConflicts(for vm: VBVirtualMachine, in library: VMLibraryController) -> Set<String> {
-        let candidates = Set(
-            vm.configuration.hardware.networkDevices
-                .map { $0.macAddress.uppercased() }
-                .filter { !$0.isEmpty }
-        )
-        guard !candidates.isEmpty else { return [] }
-
-        var runningMACs = Set<String>()
-        for runningID in library.bootedMachineIdentifiers where runningID != vm.id {
-            guard let runningVM = library.virtualMachines.first(where: { $0.id == runningID }) else { continue }
-            for device in runningVM.configuration.hardware.networkDevices {
-                let mac = device.macAddress.uppercased()
-                if !mac.isEmpty { runningMACs.insert(mac) }
-            }
-        }
-
-        return candidates.intersection(runningMACs)
-    }
-
-    private func presentMACAddressConflictAlert(conflicts: Set<String>) async -> MACAddressConflictResolution {
+    private func presentMACAddressConflictAlert(conflicts: Set<String>) async -> VMController.MACAddressConflictResolution {
         let alert = NSAlert()
         alert.messageText = "Duplicate MAC Address"
         let formattedConflicts = conflicts.sorted().joined(separator: ", ")
         alert.informativeText = "One or more network devices on this virtual machine share a MAC address with a virtual machine that's already running:\n\n\(formattedConflicts)\n\nRunning multiple virtual machines with the same MAC address on the same network may cause connectivity issues."
-        alert.addButton(withTitle: "Randomize & Continue")
+        alert.addButton(withTitle: "Randomize MAC address(es) & Continue")
         alert.addButton(withTitle: "Continue Anyway")
         alert.addButton(withTitle: "Cancel")
 
@@ -119,6 +69,11 @@ public final class VirtualMachineSessionUIManager: ObservableObject {
         let vmID = vm.id
 
         let session = createSession(for: vm, library: library, options: options)
+
+        session.controller.macAddressConflictHandler = { [weak self] conflicts in
+            guard let self else { return .cancel }
+            return await self.presentMACAddressConflictAlert(conflicts: conflicts)
+        }
 
         openWindow(id: vmID) {
             VirtualMachineSessionView()

--- a/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Virtualization
 import VirtualCore
 import Combine
 import OSLog
@@ -37,8 +38,99 @@ public final class VirtualMachineSessionUIManager: ObservableObject {
         if let existingSession = session(for: vm) {
             existingSession.update(with: options)
             existingSession.bringToFront()
-        } else {
+            return
+        }
+
+        let conflicts = findMACAddressConflicts(for: vm, in: library)
+        guard !conflicts.isEmpty else {
             launchNewSession(for: vm, library: library, options: options)
+            return
+        }
+
+        Task {
+            await resolveMACAddressConflictsAndLaunch(
+                vm: vm,
+                conflicts: conflicts,
+                library: library,
+                options: options
+            )
+        }
+    }
+
+    private enum MACAddressConflictResolution {
+        case cancel
+        case continueAnyway
+        case randomize
+    }
+
+    private func findMACAddressConflicts(for vm: VBVirtualMachine, in library: VMLibraryController) -> Set<String> {
+        let candidates = Set(
+            vm.configuration.hardware.networkDevices
+                .map { $0.macAddress.uppercased() }
+                .filter { !$0.isEmpty }
+        )
+        guard !candidates.isEmpty else { return [] }
+
+        var runningMACs = Set<String>()
+        for runningID in library.bootedMachineIdentifiers where runningID != vm.id {
+            guard let runningVM = library.virtualMachines.first(where: { $0.id == runningID }) else { continue }
+            for device in runningVM.configuration.hardware.networkDevices {
+                let mac = device.macAddress.uppercased()
+                if !mac.isEmpty { runningMACs.insert(mac) }
+            }
+        }
+
+        return candidates.intersection(runningMACs)
+    }
+
+    private func resolveMACAddressConflictsAndLaunch(
+        vm: VBVirtualMachine,
+        conflicts: Set<String>,
+        library: VMLibraryController,
+        options: VMSessionOptions?
+    ) async {
+        switch await presentMACAddressConflictAlert(conflicts: conflicts) {
+        case .cancel:
+            return
+        case .continueAnyway:
+            launchNewSession(for: vm, library: library, options: options)
+        case .randomize:
+            var updatedVM = vm
+            for index in updatedVM.configuration.hardware.networkDevices.indices {
+                updatedVM.configuration.hardware.networkDevices[index].macAddress = VZMACAddress.randomLocallyAdministered().string.uppercased()
+            }
+            do {
+                try updatedVM.saveMetadata()
+                library.reload()
+            } catch {
+                logger.error("Failed to save randomized MAC addresses for \(updatedVM.name, privacy: .public): \(error, privacy: .public)")
+                NSAlert(error: error).runModal()
+                return
+            }
+            launchNewSession(for: updatedVM, library: library, options: options)
+        }
+    }
+
+    private func presentMACAddressConflictAlert(conflicts: Set<String>) async -> MACAddressConflictResolution {
+        let alert = NSAlert()
+        alert.messageText = "Duplicate MAC Address"
+        let formattedConflicts = conflicts.sorted().joined(separator: ", ")
+        alert.informativeText = "One or more network devices on this virtual machine share a MAC address with a virtual machine that's already running:\n\n\(formattedConflicts)\n\nRunning multiple virtual machines with the same MAC address on the same network may cause connectivity issues."
+        alert.addButton(withTitle: "Randomize & Continue")
+        alert.addButton(withTitle: "Continue Anyway")
+        alert.addButton(withTitle: "Cancel")
+
+        let response: NSApplication.ModalResponse
+        if let window = NSApp?.keyWindow {
+            response = await alert.beginSheetModal(for: window)
+        } else {
+            response = alert.runModal()
+        }
+
+        switch response {
+        case .alertFirstButtonReturn: return .randomize
+        case .alertSecondButtonReturn: return .continueAnyway
+        default: return .cancel
         }
     }
 

--- a/VirtualUI/Source/Session/VirtualMachineSessionView.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionView.swift
@@ -67,7 +67,7 @@ public struct VirtualMachineSessionView: View {
             }
             .task {
                 if controller.options.autoBoot {
-                    Task { await sessionManager.startVM(controller: controller, library: library) }
+                    Task { try? await controller.start() }
                 }
             }
             .toolbar {
@@ -176,7 +176,7 @@ public struct VirtualMachineSessionView: View {
     private var circularStartButton: some View {
         Button {
             if controller.canStart {
-                Task { await sessionManager.startVM(controller: controller, library: library) }
+                Task { try? await controller.start() }
             } else if controller.canResume {
                 Task {
                     try? await controller.resume()

--- a/VirtualUI/Source/Session/VirtualMachineSessionView.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionView.swift
@@ -67,7 +67,7 @@ public struct VirtualMachineSessionView: View {
             }
             .task {
                 if controller.options.autoBoot {
-                    Task { try? await controller.start() }
+                    Task { await sessionManager.startVM(controller: controller, library: library) }
                 }
             }
             .toolbar {
@@ -176,7 +176,7 @@ public struct VirtualMachineSessionView: View {
     private var circularStartButton: some View {
         Button {
             if controller.canStart {
-                Task { try? await controller.start() }
+                Task { await sessionManager.startVM(controller: controller, library: library) }
             } else if controller.canResume {
                 Task {
                     try? await controller.resume()


### PR DESCRIPTION
## Summary

Detect conflicting MAC addresses when a VM starts and give the user the option to randomize the conflicting MAC, continue anyway, or cancel the launch.

_This code was written with Claude, reviewed by me, tested on my MacBook._

## Problem

When VMs are duplicated, they also duplicate the network device's MAC address. If both VMs are launched at the same time, this causes networking issues which can be hard to diagnose and we don't show any errors currently.

## Solution

When a VM is being launched, see if any currently running VM(s) have a conflicting MAC address. If so, alert the user to the situation and provide an option to randomize this VM's conflicting MAC address. Choosing Randomize & Continue persists the new MAC to the VM's metadata.

<img width="547" height="790" alt="image" src="https://github.com/user-attachments/assets/36cc4a05-c735-4776-8828-ab25f73c2776" />

The check runs inside `VMController.start()` so every start path (auto-boot via virtualbuddy://boot, the in-window start button, and the toolbar play button) is gated by this check. The alert presentation in `VirtualUI` is injected as a closure on `VMController.macAddressConflictHandler` when the session is created. Resume is intentionally not gated since I assume a paused VM already went through this check on start.

## Testing

I tested these scenarios locally with a dev build:

1. Launching 2 Mac machines with the same MAC addresses at the same time
   Result: second machine get prompt to randomize MAC address ✅
2. Launched Mac 1 machine, shut it down, launched Mac 2 with same MAC address
   Result: no prompts ✅
3. Launching 2 Mac machines, with different MAC addresses
   Result: no prompts ✅
4. Launching 2 Linux machines with the same MAC addresses at the same time
   Result: second machine get prompt to randomize MAC address ✅
5. Launching 2 machines and force quiting VirtualBuddy
   1. Launch first Linux machine, open terminal to check MAC address
   2. Launch second Linux machine with the same MAC address, click "Randomize MAC Address & Continue", open terminal to check it has a different MAC address
   3. Force quit VirtualBuddy
   4. Re-launch VirtualBuddy, verify MAC addresses were saved.

   Result: Linux machines launched with different MAC addresses, MAC addresses were saved properly. ✅
6. Triggered conflict, clicked Cancel.
   Result: session window stays open, VM does not boot ✅

## Alternatives considered

https://github.com/apfritts/VirtualBuddy/pull/1
This added a randomize button in VM Settings and automatically randomized MAC addresses when duplicating a VM. I decided this was a little magical, and some users may not be running a duplicated VM at the same time as the original, and may want the MAC address to stay the same.

## Related
https://github.com/insidegui/VirtualBuddy/discussions/351
