### PR TITLE
Require macOS 27 host for macOS 27 guest beta 1 (at least for now)

### DIFF
--- a/data/ipsws_v2.json
+++ b/data/ipsws_v2.json
@@ -215,7 +215,19 @@
       "minCPUCount" : 2,
       "minMemorySizeMB" : 4096,
       "minVersionHost" : "13.0.0"
-    }
+    },
+        {
+            "id": "min_host_26",
+            "minCPUCount": 2,
+            "minMemorySizeMB": 4096,
+            "minVersionHost": "26.0.0"
+        },
+        {
+            "id": "min_host_27",
+            "minCPUCount": 2,
+            "minMemorySizeMB": 4096,
+            "minVersionHost": "27.0.0"
+        }
   ],
   "restoreImages" : [
     {
@@ -226,7 +238,7 @@
       "id" : "25G5028f",
       "mobileDeviceMinVersion" : "1827.100.14",
       "name" : "macOS 26.6 Developer Beta 1",
-      "requirements" : "min_host_13",
+      "requirements" : "min_host_27",
       "url" : "https:\/\/updates.cdn-apple.com\/2026SpringSeed\/fullrestores\/122-66788\/E1D3F6EB-514E-4A9B-833A-2A82621ACA18\/UniversalMac_26.6_25G5028f_Restore.ipsw",
       "version" : "26.6.0"
     },


### PR DESCRIPTION
Installation doesn't work in macOS 26.x host, so make macOS 27 beta 1 show up with a warning in the catalog UI for now.