### PR TITLE
Add GitHub Actions build and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - "ci/**"
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - "ci/**"
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build and test
+    runs-on: macos-26
+    timeout-minutes: 45
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.5.app/Contents/Developer
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Show build environment
+        run: |
+          sw_vers
+          xcodebuild -version
+
+      - name: Resolve package dependencies
+        run: |
+          xcodebuild \
+            -project VirtualBuddy.xcodeproj \
+            -resolvePackageDependencies
+
+      - name: Build products
+        run: |
+          for scheme in VirtualBuddy VirtualBuddyGuest vctool; do
+            xcodebuild \
+              -project VirtualBuddy.xcodeproj \
+              -scheme "$scheme" \
+              -configuration Debug \
+              -destination "platform=macOS,arch=arm64" \
+              -derivedDataPath "$RUNNER_TEMP/VirtualBuddyDerivedData" \
+              CODE_SIGNING_ALLOWED=NO \
+              CODE_SIGNING_REQUIRED=NO \
+              build
+          done
+
+      - name: Run tests
+        run: |
+          xcodebuild \
+            -project VirtualBuddy.xcodeproj \
+            -scheme VirtualWormhole \
+            -configuration Debug \
+            -destination "platform=macOS,arch=arm64" \
+            -derivedDataPath "$RUNNER_TEMP/VirtualBuddyDerivedData" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            test

--- a/VirtualWormholeTests/WormholePacketTests.swift
+++ b/VirtualWormholeTests/WormholePacketTests.swift
@@ -15,7 +15,11 @@ final class WormholePacketTests: XCTestCase {
         let packet = try WormholePacket(payload)
         let data = try packet.encoded()
 
-        XCTAssertEqual(data.hexDump, "CAFEF00D546573745061796C6F6164003A000000000000007B226D657373616765223A2248656C6C6F2C20576F726C6421222C226E756D626572223A34322C2264617461223A227172764D3365375C2F227D")
+        XCTAssertEqual(data.prefix(24).hexDump, "CAFEF00D546573745061796C6F6164003A00000000000000")
+
+        let decodedPacket = try WormholePacket.decode(from: data)
+        let decodedPayload = try JSONDecoder().decode(TestPayload.self, from: decodedPacket.payload)
+        XCTAssertEqual(decodedPayload, payload)
     }
 
     func testPacketDecodingWithTestPayload() throws {
@@ -81,7 +85,7 @@ final class WormholePacketTests: XCTestCase {
 
 }
 
-struct TestPayload: Codable {
+struct TestPayload: Codable, Equatable {
     var message = "Hello, World!"
     var number = 42
     var data = Data([0xAA,0xBB,0xCC,0xDD,0xEE,0xFF])


### PR DESCRIPTION
## Summary

- add a GitHub Actions workflow that builds the VirtualBuddy host app, guest app, and `vctool`
- run the existing VirtualWormhole test suite on an ARM macOS runner
- make the packet encoding test independent of unspecified JSON object key ordering

## Why

The repository currently has no automated build or test gate. This adds a focused CI check for the shipping products and existing tests without requiring signing credentials or persistent artifacts.

The existing packet encoding assertion compared the entire JSON payload byte-for-byte. JSON object key ordering is not guaranteed and differs between toolchains, so the test now keeps the binary packet header assertion exact while comparing the decoded payload semantically.

## Validation

- built `VirtualBuddy`, `VirtualBuddyGuest`, and `vctool` locally with Xcode 27 and code signing disabled
- ran all VirtualWormhole tests locally
- passed a fork branch-push workflow run: https://github.com/brndnsvr/VirtualBuddy/actions/runs/29193208621
- passed fork pull-request workflow runs, including the final upstream-ready workflow: https://github.com/brndnsvr/VirtualBuddy/actions/runs/29193420584
