### PR TITLE
Add macOS 27.0 beta 3 v.2

### DIFF
--- a/data/ipsws_v2.json
+++ b/data/ipsws_v2.json
@@ -274,6 +274,18 @@
   ],
   "restoreImages" : [
     {
+      "build" : "26A5378n",
+      "channel" : "devbeta",
+      "downloadSize" : 22590067379,
+      "group" : "goldengate",
+      "id" : "26A5378n",
+      "mobileDeviceMinVersion" : "1853.0.0",
+      "name" : "macOS 27.0 Developer Beta 3 v.2",
+      "requirements" : "min_host_26_virtual_installation",
+      "url" : "https:\/\/updates.cdn-apple.com\/2026SummerSeed\/fullrestores\/140-37973\/1ACA049C-10F0-4F1D-8E38-E52B9168C4BC\/UniversalMac_27.0_26A5378n_Restore.ipsw",
+      "version" : "27.0.0"
+    },
+    {
       "build" : "26A5378j",
       "channel" : "devbeta",
       "downloadSize" : 22567352533,


### PR DESCRIPTION
This is how Apple named the public beta release 🤷🏻‍♂️

<img width="498" height="219" alt="Screenshot 2026-07-13 at 16 57 29" src="https://github.com/user-attachments/assets/e6029690-48a1-45b8-8374-6e9b66e9e528" />
