### PR TITLE
Monitor host bridge network interface and reattach when availability changes (#716)

### DIFF
--- a/VirtualBuddy.xcodeproj/project.pbxproj
+++ b/VirtualBuddy.xcodeproj/project.pbxproj
@@ -338,6 +338,7 @@
 		F4DE1C0F2D6F603300603527 /* VBSavedStatePackage+VM.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DE1C0E2D6F603300603527 /* VBSavedStatePackage+VM.swift */; };
 		F4DE1C112D6F642E00603527 /* VBStorageDeviceContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DE1C102D6F642E00603527 /* VBStorageDeviceContainer.swift */; };
 		F4DF12ED2FDC824800540CF4 /* VirtualInstallation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F4EFB5632FDB2A0D00AF2A63 /* VirtualInstallation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F4E4D5DD300FB2F8004A6235 /* VMNetworkAttachmentHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E4D5DC300FB2F3004A6235 /* VMNetworkAttachmentHelper.swift */; };
 		F4E4F6C52DEF96C200B3B8BA /* ChromeBorderModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E4F6C42DEF96C200B3B8BA /* ChromeBorderModifier.swift */; };
 		F4E4F7202DF080FC00B3B8BA /* RestoreImageSelectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E4F71F2DF080FC00B3B8BA /* RestoreImageSelectionController.swift */; };
 		F4E7680A29B64C590075A897 /* GuestTypePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E7680929B64C590075A897 /* GuestTypePicker.swift */; };
@@ -911,6 +912,7 @@
 		F4DE1C0A2D6F54E000603527 /* VBSavedStateMetadata+Clone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VBSavedStateMetadata+Clone.swift"; sourceTree = "<group>"; };
 		F4DE1C0E2D6F603300603527 /* VBSavedStatePackage+VM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VBSavedStatePackage+VM.swift"; sourceTree = "<group>"; };
 		F4DE1C102D6F642E00603527 /* VBStorageDeviceContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VBStorageDeviceContainer.swift; sourceTree = "<group>"; };
+		F4E4D5DC300FB2F3004A6235 /* VMNetworkAttachmentHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMNetworkAttachmentHelper.swift; sourceTree = "<group>"; };
 		F4E4F6C42DEF96C200B3B8BA /* ChromeBorderModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeBorderModifier.swift; sourceTree = "<group>"; };
 		F4E4F71F2DF080FC00B3B8BA /* RestoreImageSelectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreImageSelectionController.swift; sourceTree = "<group>"; };
 		F4E7680929B64C590075A897 /* GuestTypePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuestTypePicker.swift; sourceTree = "<group>"; };
@@ -1760,6 +1762,7 @@
 				F46FFBAB28059FF600D61023 /* VMInstance.swift */,
 				F4BE9C7927FF05B900B648F8 /* VMController.swift */,
 				F44C00FA2889CE1600640BF5 /* VBVirtualMachine+Virtualization.swift */,
+				F4E4D5DC300FB2F3004A6235 /* VMNetworkAttachmentHelper.swift */,
 			);
 			path = Virtualization;
 			sourceTree = "<group>";
@@ -2949,6 +2952,7 @@
 				F485B91F2BB2F4AC004B3C2B /* Bundle+Version.swift in Sources */,
 				F49A68E12884917E00A17582 /* ConfigurationModels.swift in Sources */,
 				F485B91D2BB2F0D9004B3C2B /* ProcessInfo+ECID.swift in Sources */,
+				F4E4D5DD300FB2F8004A6235 /* VMNetworkAttachmentHelper.swift in Sources */,
 				F444D1342BB478AD00AB786F /* VBMemoryLeakDebugAssertions.swift in Sources */,
 				F4C237502888AF67001FF286 /* LogStreamer.swift in Sources */,
 				F4F9B41A284CE37C00F21737 /* Logging.swift in Sources */,

--- a/VirtualBuddy/Bootstrap/VirtualBuddyApp.swift
+++ b/VirtualBuddy/Bootstrap/VirtualBuddyApp.swift
@@ -61,6 +61,11 @@ struct VirtualBuddyApp: App {
                 .keyboardShortcut(",", modifiers: .command)
             }
 
+            CommandMenu("Guest") {
+                VirtualMachineGuestCommands()
+                    .environmentObject(sessionManager)
+            }
+
             CommandGroup(before: .windowSize) {
                 VirtualMachineWindowCommands()
                     .environmentObject(sessionManager)

--- a/VirtualCore/Source/Virtualization/VMController.swift
+++ b/VirtualCore/Source/Virtualization/VMController.swift
@@ -372,6 +372,12 @@ public final class VMController: ObservableObject {
         unhideCursor()
     }
 
+    /// Replaces the running virtual machine's network attachments and starts automatic retries for
+    /// any host interfaces that are not available yet.
+    public func reconnectNetwork() throws {
+        try ensureInstance().reconnectNetwork()
+    }
+
     @available(macOS 14.0, *)
     public func saveState(snapshotName name: String) async throws {
         try await updatingState {
@@ -542,6 +548,8 @@ public extension VMController {
     var canResume: Bool { state.canResume }
 
     var canPause: Bool { state.canPause }
+
+    var canReconnectNetwork: Bool { state.isRunning || state.isPaused }
 
 }
 

--- a/VirtualCore/Source/Virtualization/VMController.swift
+++ b/VirtualCore/Source/Virtualization/VMController.swift
@@ -378,6 +378,23 @@ public final class VMController: ObservableObject {
         try ensureInstance().reconnectNetwork()
     }
 
+    public var availableBridgeInterfaces: [VBNetworkDeviceInterface] {
+        VBNetworkDevice.bridgeInterfaces.sorted { lhs, rhs in
+            let nameOrder = lhs.name.localizedStandardCompare(rhs.name)
+            return nameOrder == .orderedSame ? lhs.id < rhs.id : nameOrder == .orderedAscending
+        }
+    }
+
+    public var activeBridgeInterfaceIdentifiers: Set<String> {
+        instance?.activeBridgeInterfaceIdentifiers ?? []
+    }
+
+    public func changeBridgeInterface(to interfaceIdentifier: String) throws {
+        let instance = try ensureInstance()
+        objectWillChange.send()
+        try instance.changeBridgeInterface(to: interfaceIdentifier)
+    }
+
     @available(macOS 14.0, *)
     public func saveState(snapshotName name: String) async throws {
         try await updatingState {
@@ -550,6 +567,10 @@ public extension VMController {
     var canPause: Bool { state.canPause }
 
     var canReconnectNetwork: Bool { state.isRunning || state.isPaused }
+
+    var canChangeBridgeInterface: Bool {
+        canReconnectNetwork && instance?.hasBridgedNetworkAttachments == true
+    }
 
 }
 

--- a/VirtualCore/Source/Virtualization/VMInstance.swift
+++ b/VirtualCore/Source/Virtualization/VMInstance.swift
@@ -15,48 +15,6 @@ import VirtualWormhole
 @MainActor
 public final class VMInstance: NSObject, ObservableObject {
 
-    private struct NetworkAttachmentRecoveryConfiguration {
-        enum Kind {
-            case NAT
-            case bridge(interfaceIdentifier: String)
-        }
-
-        let kind: Kind
-        let macAddress: String
-
-        var description: String {
-            switch kind {
-            case .NAT:
-                return "NAT"
-            case .bridge(let interfaceIdentifier):
-                return "bridge(\(interfaceIdentifier))"
-            }
-        }
-
-        func makeAttachment() throws -> VZNetworkDeviceAttachment {
-            switch kind {
-            case .NAT:
-                return VZNATNetworkDeviceAttachment()
-            case .bridge(let interfaceIdentifier):
-                guard let interface = VZBridgedNetworkInterface.networkInterfaces.first(where: {
-                    $0.identifier == interfaceIdentifier
-                }) else {
-                    throw Failure("The bridged network interface \(interfaceIdentifier.quoted) is not currently available.")
-                }
-
-                return VZBridgedNetworkDeviceAttachment(interface: interface)
-            }
-        }
-    }
-
-    private struct NetworkAttachmentRecoveryTask {
-        let id: UUID
-        let task: Task<Void, Never>
-    }
-
-    private static let networkAttachmentRecoveryDelays: [TimeInterval] = [1, 2, 4, 8, 15, 30]
-    private static let networkAttachmentStabilizationDelay: TimeInterval = 1
-
     private let library: VMLibraryController
 
     private let logger: Logger
@@ -65,8 +23,7 @@ public final class VMInstance: NSObject, ObservableObject {
 
     private var _virtualMachine: VZVirtualMachine?
 
-    private var networkAttachmentRecoveryConfigurations: [NetworkAttachmentRecoveryConfiguration?] = []
-    private var networkAttachmentRecoveryTasks: [Int: NetworkAttachmentRecoveryTask] = [:]
+    private var networkAttachmentHelper: VMNetworkAttachmentHelper?
     
     var virtualMachine: VZVirtualMachine {
         get throws {
@@ -207,37 +164,15 @@ public final class VMInstance: NSObject, ObservableObject {
             throw Failure("Failed to validate configuration: \(String(describing: error))")
         }
 
+        networkAttachmentHelper?.stop()
+
         let virtualMachine = VZVirtualMachine(configuration: config)
         _virtualMachine = virtualMachine
-        configureNetworkAttachmentRecovery(with: config)
-    }
-
-    private func configureNetworkAttachmentRecovery(with configuration: VZVirtualMachineConfiguration) {
-        cancelNetworkAttachmentRecovery()
-
-        networkAttachmentRecoveryConfigurations = configuration.networkDevices.enumerated().map { index, device in
-            guard let attachment = device.attachment else {
-                logger.error("Network device \(index) has no attachment; automatic recovery will be unavailable for this device")
-                return nil
-            }
-
-            let recoveryKind: NetworkAttachmentRecoveryConfiguration.Kind
-
-            switch attachment {
-            case is VZNATNetworkDeviceAttachment:
-                recoveryKind = .NAT
-            case let bridge as VZBridgedNetworkDeviceAttachment:
-                recoveryKind = .bridge(interfaceIdentifier: bridge.interface.identifier)
-            default:
-                logger.error("Network device \(index) uses unsupported attachment type \(String(describing: type(of: attachment)), privacy: .public); automatic recovery will be unavailable for this device")
-                return nil
-            }
-
-            return NetworkAttachmentRecoveryConfiguration(
-                kind: recoveryKind,
-                macAddress: device.macAddress.string.uppercased()
-            )
-        }
+        networkAttachmentHelper = VMNetworkAttachmentHelper(
+            virtualMachine: virtualMachine,
+            configuration: config,
+            logger: logger
+        )
     }
 
     private func setupWormhole(for config: VZVirtualMachineConfiguration) async {
@@ -350,6 +285,8 @@ public final class VMInstance: NSObject, ObservableObject {
 
         try await vm.start(options: startOptions)
 
+        networkAttachmentHelper?.startMonitoringHostInterfaces()
+
         #if DEBUG
         VBDebugUtil.debugVirtualMachine(afterStart: vm)
         #endif
@@ -400,7 +337,7 @@ public final class VMInstance: NSObject, ObservableObject {
         
         try await vm.stop()
 
-        cancelNetworkAttachmentRecovery()
+        networkAttachmentHelper?.stop()
 
         library.unregisterBootedVM(self)
     }
@@ -410,27 +347,11 @@ public final class VMInstance: NSObject, ObservableObject {
     /// Automatic bridge configurations remain pinned to the interface selected when the VM was
     /// created. This avoids unexpectedly moving the guest's MAC address to a different network.
     func reconnectNetwork() throws {
-        let virtualMachine = try ensureVM()
-        var scheduledDeviceCount = 0
-
-        for index in virtualMachine.networkDevices.indices {
-            guard networkAttachmentRecoveryConfigurations.indices.contains(index),
-                  networkAttachmentRecoveryConfigurations[index] != nil
-            else { continue }
-
-            scheduleNetworkAttachmentRecovery(
-                forDeviceAt: index,
-                in: virtualMachine,
-                replacingCurrentAttachment: true
-            )
-            scheduledDeviceCount += 1
+        guard let networkAttachmentHelper else {
+            throw Failure("The virtual machine's network attachment manager is unavailable.")
         }
 
-        guard scheduledDeviceCount > 0 else {
-            throw Failure("This virtual machine has no network attachments that can be reconnected.")
-        }
-
-        logger.info("Manual network reconnection scheduled for \(scheduledDeviceCount) device(s)")
+        try networkAttachmentHelper.reconnectAll()
     }
 
     @available(macOS 14.0, *)
@@ -534,6 +455,8 @@ public final class VMInstance: NSObject, ObservableObject {
 
             try await resume()
 
+            networkAttachmentHelper?.startMonitoringHostInterfaces()
+
             #if DEBUG
             VBDebugUtil.debugVirtualMachine(afterStart: vm)
             #endif
@@ -620,7 +543,7 @@ extension VMInstance: VZVirtualMachineDelegate {
     
     public nonisolated func virtualMachine(_ virtualMachine: VZVirtualMachine, networkDevice: VZNetworkDevice, attachmentWasDisconnectedWithError error: Error) {
         MainActor.assumeIsolated {
-            handleNetworkAttachmentDisconnection(
+            networkAttachmentHelper?.attachmentWasDisconnected(
                 in: virtualMachine,
                 networkDevice: networkDevice,
                 error: error
@@ -628,139 +551,8 @@ extension VMInstance: VZVirtualMachineDelegate {
         }
     }
 
-    private func handleNetworkAttachmentDisconnection(
-        in virtualMachine: VZVirtualMachine,
-        networkDevice: VZNetworkDevice,
-        error: Error
-    ) {
-        let nsError = error as NSError
-        let attachmentDescription = String(describing: networkDevice.attachment)
-
-        guard let deviceIndex = virtualMachine.networkDevices.firstIndex(where: { $0 === networkDevice }) else {
-            logger.error("A network attachment disconnected but its device is not part of the VM: domain=\(nsError.domain, privacy: .public) code=\(nsError.code) error=\(nsError.localizedDescription, privacy: .public) userInfo=\(String(describing: nsError.userInfo), privacy: .public) attachment=\(attachmentDescription, privacy: .public)")
-            return
-        }
-
-        let macAddress = networkAttachmentRecoveryConfigurations.indices.contains(deviceIndex)
-            ? networkAttachmentRecoveryConfigurations[deviceIndex]?.macAddress ?? "unknown"
-            : "unknown"
-
-        logger.error("Network attachment disconnected: device=\(deviceIndex) MAC=\(macAddress, privacy: .public) domain=\(nsError.domain, privacy: .public) code=\(nsError.code) error=\(nsError.localizedDescription, privacy: .public) userInfo=\(String(describing: nsError.userInfo), privacy: .public) attachment=\(attachmentDescription, privacy: .public)")
-
-        guard _virtualMachine === virtualMachine else {
-            logger.info("Ignoring network disconnection from a stale VM instance")
-            return
-        }
-
-        guard networkAttachmentRecoveryConfigurations.indices.contains(deviceIndex),
-              networkAttachmentRecoveryConfigurations[deviceIndex] != nil
-        else {
-            logger.error("No recovery configuration is available for network device \(deviceIndex)")
-            return
-        }
-
-        guard networkAttachmentRecoveryTasks[deviceIndex] == nil else {
-            logger.debug("Network recovery is already active for device \(deviceIndex)")
-            return
-        }
-
-        scheduleNetworkAttachmentRecovery(forDeviceAt: deviceIndex, in: virtualMachine)
-    }
-
-    private func scheduleNetworkAttachmentRecovery(
-        forDeviceAt deviceIndex: Int,
-        in virtualMachine: VZVirtualMachine,
-        replacingCurrentAttachment: Bool = false
-    ) {
-        guard virtualMachine.networkDevices.indices.contains(deviceIndex),
-              networkAttachmentRecoveryConfigurations.indices.contains(deviceIndex),
-              let recoveryConfiguration = networkAttachmentRecoveryConfigurations[deviceIndex]
-        else {
-            logger.error("Unable to schedule recovery for network device \(deviceIndex): recovery configuration is unavailable")
-            return
-        }
-
-        if let existingTask = networkAttachmentRecoveryTasks.removeValue(forKey: deviceIndex) {
-            existingTask.task.cancel()
-        }
-
-        let networkDevice = virtualMachine.networkDevices[deviceIndex]
-        let taskID = UUID()
-        let initialDelay: TimeInterval = replacingCurrentAttachment ? 0 : Self.networkAttachmentRecoveryDelays[0]
-
-        let task = Task { @MainActor [weak self, weak virtualMachine, weak networkDevice] in
-            var attempt = 0
-            var shouldReplaceCurrentAttachment = replacingCurrentAttachment
-            var nextDelay = initialDelay
-
-            defer {
-                self?.networkAttachmentRecoveryDidFinish(forDeviceAt: deviceIndex, taskID: taskID)
-            }
-
-            while !Task.isCancelled {
-                do {
-                    try await Task.sleep(for: .seconds(nextDelay))
-                } catch {
-                    return
-                }
-
-                guard let self, let virtualMachine, let networkDevice,
-                      self._virtualMachine === virtualMachine
-                else { return }
-
-                if networkDevice.attachment != nil && !shouldReplaceCurrentAttachment {
-                    self.logger.info("Network device \(deviceIndex) recovered before retry was necessary")
-                    return
-                }
-
-                shouldReplaceCurrentAttachment = false
-                attempt += 1
-
-                self.logger.info("Attempting to reconnect network device \(deviceIndex) (\(recoveryConfiguration.description, privacy: .public), MAC=\(recoveryConfiguration.macAddress, privacy: .public), attempt=\(attempt))")
-
-                do {
-                    let newAttachment = try recoveryConfiguration.makeAttachment()
-                    networkDevice.attachment = newAttachment
-
-                    self.logger.debug("Assigned new attachment to network device \(deviceIndex): \(String(describing: newAttachment), privacy: .public)")
-
-                    try await Task.sleep(for: .seconds(Self.networkAttachmentStabilizationDelay))
-
-                    guard self._virtualMachine === virtualMachine else { return }
-
-                    if networkDevice.attachment != nil {
-                        self.logger.info("Successfully reconnected network device \(deviceIndex) (\(recoveryConfiguration.description, privacy: .public), MAC=\(recoveryConfiguration.macAddress, privacy: .public))")
-                        return
-                    }
-
-                    self.logger.error("Network device \(deviceIndex) rejected the replacement attachment; retrying")
-                } catch is CancellationError {
-                    return
-                } catch {
-                    self.logger.error("Failed to reconnect network device \(deviceIndex) on attempt \(attempt): \(error, privacy: .public)")
-                }
-
-                let delayIndex = min(attempt, Self.networkAttachmentRecoveryDelays.count - 1)
-                nextDelay = Self.networkAttachmentRecoveryDelays[delayIndex]
-            }
-        }
-
-        networkAttachmentRecoveryTasks[deviceIndex] = NetworkAttachmentRecoveryTask(id: taskID, task: task)
-    }
-
-    private func networkAttachmentRecoveryDidFinish(forDeviceAt deviceIndex: Int, taskID: UUID) {
-        guard networkAttachmentRecoveryTasks[deviceIndex]?.id == taskID else { return }
-
-        networkAttachmentRecoveryTasks.removeValue(forKey: deviceIndex)
-    }
-
-    private func cancelNetworkAttachmentRecovery() {
-        networkAttachmentRecoveryTasks.values.forEach { $0.task.cancel() }
-        networkAttachmentRecoveryTasks.removeAll()
-    }
-
     private func handleGuestStopped(with error: Error?) {
-        cancelNetworkAttachmentRecovery()
+        networkAttachmentHelper?.stop()
 
         guestIOTasks.forEach { $0.cancel() }
         guestIOTasks.removeAll()

--- a/VirtualCore/Source/Virtualization/VMInstance.swift
+++ b/VirtualCore/Source/Virtualization/VMInstance.swift
@@ -354,6 +354,22 @@ public final class VMInstance: NSObject, ObservableObject {
         try networkAttachmentHelper.reconnectAll()
     }
 
+    var activeBridgeInterfaceIdentifiers: Set<String> {
+        networkAttachmentHelper?.bridgeInterfaceIdentifiers ?? []
+    }
+
+    var hasBridgedNetworkAttachments: Bool {
+        networkAttachmentHelper?.hasBridgedAttachments == true
+    }
+
+    func changeBridgeInterface(to interfaceIdentifier: String) throws {
+        guard let networkAttachmentHelper else {
+            throw Failure("The virtual machine's network attachment manager is unavailable.")
+        }
+
+        try networkAttachmentHelper.changeBridgeInterface(to: interfaceIdentifier)
+    }
+
     @available(macOS 14.0, *)
     @discardableResult
     func saveState(snapshotName name: String, onStart: () -> ()) async throws -> VBSavedStatePackage {

--- a/VirtualCore/Source/Virtualization/VMInstance.swift
+++ b/VirtualCore/Source/Virtualization/VMInstance.swift
@@ -15,6 +15,48 @@ import VirtualWormhole
 @MainActor
 public final class VMInstance: NSObject, ObservableObject {
 
+    private struct NetworkAttachmentRecoveryConfiguration {
+        enum Kind {
+            case NAT
+            case bridge(interfaceIdentifier: String)
+        }
+
+        let kind: Kind
+        let macAddress: String
+
+        var description: String {
+            switch kind {
+            case .NAT:
+                return "NAT"
+            case .bridge(let interfaceIdentifier):
+                return "bridge(\(interfaceIdentifier))"
+            }
+        }
+
+        func makeAttachment() throws -> VZNetworkDeviceAttachment {
+            switch kind {
+            case .NAT:
+                return VZNATNetworkDeviceAttachment()
+            case .bridge(let interfaceIdentifier):
+                guard let interface = VZBridgedNetworkInterface.networkInterfaces.first(where: {
+                    $0.identifier == interfaceIdentifier
+                }) else {
+                    throw Failure("The bridged network interface \(interfaceIdentifier.quoted) is not currently available.")
+                }
+
+                return VZBridgedNetworkDeviceAttachment(interface: interface)
+            }
+        }
+    }
+
+    private struct NetworkAttachmentRecoveryTask {
+        let id: UUID
+        let task: Task<Void, Never>
+    }
+
+    private static let networkAttachmentRecoveryDelays: [TimeInterval] = [1, 2, 4, 8, 15, 30]
+    private static let networkAttachmentStabilizationDelay: TimeInterval = 1
+
     private let library: VMLibraryController
 
     private let logger: Logger
@@ -22,6 +64,9 @@ public final class VMInstance: NSObject, ObservableObject {
     var options = VMSessionOptions.default
 
     private var _virtualMachine: VZVirtualMachine?
+
+    private var networkAttachmentRecoveryConfigurations: [NetworkAttachmentRecoveryConfiguration?] = []
+    private var networkAttachmentRecoveryTasks: [Int: NetworkAttachmentRecoveryTask] = [:]
     
     var virtualMachine: VZVirtualMachine {
         get throws {
@@ -162,7 +207,37 @@ public final class VMInstance: NSObject, ObservableObject {
             throw Failure("Failed to validate configuration: \(String(describing: error))")
         }
 
-        _virtualMachine = VZVirtualMachine(configuration: config)
+        let virtualMachine = VZVirtualMachine(configuration: config)
+        _virtualMachine = virtualMachine
+        configureNetworkAttachmentRecovery(with: config)
+    }
+
+    private func configureNetworkAttachmentRecovery(with configuration: VZVirtualMachineConfiguration) {
+        cancelNetworkAttachmentRecovery()
+
+        networkAttachmentRecoveryConfigurations = configuration.networkDevices.enumerated().map { index, device in
+            guard let attachment = device.attachment else {
+                logger.error("Network device \(index) has no attachment; automatic recovery will be unavailable for this device")
+                return nil
+            }
+
+            let recoveryKind: NetworkAttachmentRecoveryConfiguration.Kind
+
+            switch attachment {
+            case is VZNATNetworkDeviceAttachment:
+                recoveryKind = .NAT
+            case let bridge as VZBridgedNetworkDeviceAttachment:
+                recoveryKind = .bridge(interfaceIdentifier: bridge.interface.identifier)
+            default:
+                logger.error("Network device \(index) uses unsupported attachment type \(String(describing: type(of: attachment)), privacy: .public); automatic recovery will be unavailable for this device")
+                return nil
+            }
+
+            return NetworkAttachmentRecoveryConfiguration(
+                kind: recoveryKind,
+                macAddress: device.macAddress.string.uppercased()
+            )
+        }
     }
 
     private func setupWormhole(for config: VZVirtualMachineConfiguration) async {
@@ -325,7 +400,37 @@ public final class VMInstance: NSObject, ObservableObject {
         
         try await vm.stop()
 
+        cancelNetworkAttachmentRecovery()
+
         library.unregisterBootedVM(self)
+    }
+
+    /// Replaces every supported network attachment on the running VM.
+    ///
+    /// Automatic bridge configurations remain pinned to the interface selected when the VM was
+    /// created. This avoids unexpectedly moving the guest's MAC address to a different network.
+    func reconnectNetwork() throws {
+        let virtualMachine = try ensureVM()
+        var scheduledDeviceCount = 0
+
+        for index in virtualMachine.networkDevices.indices {
+            guard networkAttachmentRecoveryConfigurations.indices.contains(index),
+                  networkAttachmentRecoveryConfigurations[index] != nil
+            else { continue }
+
+            scheduleNetworkAttachmentRecovery(
+                forDeviceAt: index,
+                in: virtualMachine,
+                replacingCurrentAttachment: true
+            )
+            scheduledDeviceCount += 1
+        }
+
+        guard scheduledDeviceCount > 0 else {
+            throw Failure("This virtual machine has no network attachments that can be reconnected.")
+        }
+
+        logger.info("Manual network reconnection scheduled for \(scheduledDeviceCount) device(s)")
     }
 
     @available(macOS 14.0, *)
@@ -514,10 +619,149 @@ extension VMInstance: VZVirtualMachineDelegate {
     }
     
     public nonisolated func virtualMachine(_ virtualMachine: VZVirtualMachine, networkDevice: VZNetworkDevice, attachmentWasDisconnectedWithError error: Error) {
+        MainActor.assumeIsolated {
+            handleNetworkAttachmentDisconnection(
+                in: virtualMachine,
+                networkDevice: networkDevice,
+                error: error
+            )
+        }
+    }
 
+    private func handleNetworkAttachmentDisconnection(
+        in virtualMachine: VZVirtualMachine,
+        networkDevice: VZNetworkDevice,
+        error: Error
+    ) {
+        let nsError = error as NSError
+        let attachmentDescription = String(describing: networkDevice.attachment)
+
+        guard let deviceIndex = virtualMachine.networkDevices.firstIndex(where: { $0 === networkDevice }) else {
+            logger.error("A network attachment disconnected but its device is not part of the VM: domain=\(nsError.domain, privacy: .public) code=\(nsError.code) error=\(nsError.localizedDescription, privacy: .public) userInfo=\(String(describing: nsError.userInfo), privacy: .public) attachment=\(attachmentDescription, privacy: .public)")
+            return
+        }
+
+        let macAddress = networkAttachmentRecoveryConfigurations.indices.contains(deviceIndex)
+            ? networkAttachmentRecoveryConfigurations[deviceIndex]?.macAddress ?? "unknown"
+            : "unknown"
+
+        logger.error("Network attachment disconnected: device=\(deviceIndex) MAC=\(macAddress, privacy: .public) domain=\(nsError.domain, privacy: .public) code=\(nsError.code) error=\(nsError.localizedDescription, privacy: .public) userInfo=\(String(describing: nsError.userInfo), privacy: .public) attachment=\(attachmentDescription, privacy: .public)")
+
+        guard _virtualMachine === virtualMachine else {
+            logger.info("Ignoring network disconnection from a stale VM instance")
+            return
+        }
+
+        guard networkAttachmentRecoveryConfigurations.indices.contains(deviceIndex),
+              networkAttachmentRecoveryConfigurations[deviceIndex] != nil
+        else {
+            logger.error("No recovery configuration is available for network device \(deviceIndex)")
+            return
+        }
+
+        guard networkAttachmentRecoveryTasks[deviceIndex] == nil else {
+            logger.debug("Network recovery is already active for device \(deviceIndex)")
+            return
+        }
+
+        scheduleNetworkAttachmentRecovery(forDeviceAt: deviceIndex, in: virtualMachine)
+    }
+
+    private func scheduleNetworkAttachmentRecovery(
+        forDeviceAt deviceIndex: Int,
+        in virtualMachine: VZVirtualMachine,
+        replacingCurrentAttachment: Bool = false
+    ) {
+        guard virtualMachine.networkDevices.indices.contains(deviceIndex),
+              networkAttachmentRecoveryConfigurations.indices.contains(deviceIndex),
+              let recoveryConfiguration = networkAttachmentRecoveryConfigurations[deviceIndex]
+        else {
+            logger.error("Unable to schedule recovery for network device \(deviceIndex): recovery configuration is unavailable")
+            return
+        }
+
+        if let existingTask = networkAttachmentRecoveryTasks.removeValue(forKey: deviceIndex) {
+            existingTask.task.cancel()
+        }
+
+        let networkDevice = virtualMachine.networkDevices[deviceIndex]
+        let taskID = UUID()
+        let initialDelay: TimeInterval = replacingCurrentAttachment ? 0 : Self.networkAttachmentRecoveryDelays[0]
+
+        let task = Task { @MainActor [weak self, weak virtualMachine, weak networkDevice] in
+            var attempt = 0
+            var shouldReplaceCurrentAttachment = replacingCurrentAttachment
+            var nextDelay = initialDelay
+
+            defer {
+                self?.networkAttachmentRecoveryDidFinish(forDeviceAt: deviceIndex, taskID: taskID)
+            }
+
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(nextDelay))
+                } catch {
+                    return
+                }
+
+                guard let self, let virtualMachine, let networkDevice,
+                      self._virtualMachine === virtualMachine
+                else { return }
+
+                if networkDevice.attachment != nil && !shouldReplaceCurrentAttachment {
+                    self.logger.info("Network device \(deviceIndex) recovered before retry was necessary")
+                    return
+                }
+
+                shouldReplaceCurrentAttachment = false
+                attempt += 1
+
+                self.logger.info("Attempting to reconnect network device \(deviceIndex) (\(recoveryConfiguration.description, privacy: .public), MAC=\(recoveryConfiguration.macAddress, privacy: .public), attempt=\(attempt))")
+
+                do {
+                    let newAttachment = try recoveryConfiguration.makeAttachment()
+                    networkDevice.attachment = newAttachment
+
+                    self.logger.debug("Assigned new attachment to network device \(deviceIndex): \(String(describing: newAttachment), privacy: .public)")
+
+                    try await Task.sleep(for: .seconds(Self.networkAttachmentStabilizationDelay))
+
+                    guard self._virtualMachine === virtualMachine else { return }
+
+                    if networkDevice.attachment != nil {
+                        self.logger.info("Successfully reconnected network device \(deviceIndex) (\(recoveryConfiguration.description, privacy: .public), MAC=\(recoveryConfiguration.macAddress, privacy: .public))")
+                        return
+                    }
+
+                    self.logger.error("Network device \(deviceIndex) rejected the replacement attachment; retrying")
+                } catch is CancellationError {
+                    return
+                } catch {
+                    self.logger.error("Failed to reconnect network device \(deviceIndex) on attempt \(attempt): \(error, privacy: .public)")
+                }
+
+                let delayIndex = min(attempt, Self.networkAttachmentRecoveryDelays.count - 1)
+                nextDelay = Self.networkAttachmentRecoveryDelays[delayIndex]
+            }
+        }
+
+        networkAttachmentRecoveryTasks[deviceIndex] = NetworkAttachmentRecoveryTask(id: taskID, task: task)
+    }
+
+    private func networkAttachmentRecoveryDidFinish(forDeviceAt deviceIndex: Int, taskID: UUID) {
+        guard networkAttachmentRecoveryTasks[deviceIndex]?.id == taskID else { return }
+
+        networkAttachmentRecoveryTasks.removeValue(forKey: deviceIndex)
+    }
+
+    private func cancelNetworkAttachmentRecovery() {
+        networkAttachmentRecoveryTasks.values.forEach { $0.task.cancel() }
+        networkAttachmentRecoveryTasks.removeAll()
     }
 
     private func handleGuestStopped(with error: Error?) {
+        cancelNetworkAttachmentRecovery()
+
         guestIOTasks.forEach { $0.cancel() }
         guestIOTasks.removeAll()
 

--- a/VirtualCore/Source/Virtualization/VMNetworkAttachmentHelper.swift
+++ b/VirtualCore/Source/Virtualization/VMNetworkAttachmentHelper.swift
@@ -1,0 +1,409 @@
+import Foundation
+import OSLog
+import SystemConfiguration
+import Virtualization
+
+private func vmNetworkAttachmentDynamicStoreCallback(
+    _ store: SCDynamicStore,
+    changedKeys: CFArray,
+    info: UnsafeMutableRawPointer?
+) {
+    guard let info else { return }
+
+    MainActor.assumeIsolated {
+        let helper = Unmanaged<VMNetworkAttachmentHelper>.fromOpaque(info).takeUnretainedValue()
+        let keys = (changedKeys as NSArray).compactMap { $0 as? String }
+        helper.dynamicStoreDidChange(keys)
+    }
+}
+
+@MainActor
+final class VMNetworkAttachmentHelper {
+    private struct AttachmentConfiguration {
+        enum Kind {
+            case NAT
+            case bridge(interfaceIdentifier: String)
+        }
+
+        let kind: Kind
+        let macAddress: String
+
+        var bridgeInterfaceIdentifier: String? {
+            guard case .bridge(let interfaceIdentifier) = kind else { return nil }
+            return interfaceIdentifier
+        }
+
+        var description: String {
+            switch kind {
+            case .NAT:
+                return "NAT"
+            case .bridge(let interfaceIdentifier):
+                return "bridge(\(interfaceIdentifier))"
+            }
+        }
+
+        func makeAttachment() throws -> VZNetworkDeviceAttachment {
+            switch kind {
+            case .NAT:
+                return VZNATNetworkDeviceAttachment()
+            case .bridge(let interfaceIdentifier):
+                guard let interface = VZBridgedNetworkInterface.networkInterfaces.first(where: {
+                    $0.identifier == interfaceIdentifier
+                }) else {
+                    throw Failure("The bridged network interface \(interfaceIdentifier.quoted) is not currently available.")
+                }
+
+                return VZBridgedNetworkDeviceAttachment(interface: interface)
+            }
+        }
+    }
+
+    private struct RecoveryTask {
+        let id: UUID
+        let task: Task<Void, Never>
+    }
+
+    private enum RecoveryReason: String {
+        case attachmentDisconnected
+        case hostInterfaceBecameActive
+        case manualRequest
+    }
+
+    private static let recoveryDelays: [TimeInterval] = [1, 2, 4, 8, 15, 30]
+    private static let attachmentStabilizationDelay: TimeInterval = 1
+    private static let hostInterfaceDebounceDelay: TimeInterval = 1
+
+    private let virtualMachine: VZVirtualMachine
+    private let logger: Logger
+    private let attachmentConfigurations: [AttachmentConfiguration?]
+
+    private var recoveryTasks: [Int: RecoveryTask] = [:]
+
+    private var dynamicStore: SCDynamicStore?
+    private var interfaceIdentifierByLinkKey: [String: String] = [:]
+    private var interfaceLinkStates: [String: Bool] = [:]
+
+    init(
+        virtualMachine: VZVirtualMachine,
+        configuration: VZVirtualMachineConfiguration,
+        logger: Logger
+    ) {
+        self.virtualMachine = virtualMachine
+        self.logger = logger
+        self.attachmentConfigurations = configuration.networkDevices.enumerated().map { index, device in
+            guard let attachment = device.attachment else {
+                logger.error("Network device \(index) has no attachment; automatic recovery will be unavailable for this device")
+                return nil
+            }
+
+            let kind: AttachmentConfiguration.Kind
+
+            switch attachment {
+            case is VZNATNetworkDeviceAttachment:
+                kind = .NAT
+            case let bridge as VZBridgedNetworkDeviceAttachment:
+                kind = .bridge(interfaceIdentifier: bridge.interface.identifier)
+            default:
+                logger.error("Network device \(index) uses unsupported attachment type \(String(describing: type(of: attachment)), privacy: .public); automatic recovery will be unavailable for this device")
+                return nil
+            }
+
+            return AttachmentConfiguration(
+                kind: kind,
+                macAddress: device.macAddress.string.uppercased()
+            )
+        }
+
+        if virtualMachine.networkDevices.count != configuration.networkDevices.count {
+            logger.error("Runtime network device count \(virtualMachine.networkDevices.count) does not match configuration count \(configuration.networkDevices.count)")
+        }
+    }
+
+    func startMonitoringHostInterfaces() {
+        guard dynamicStore == nil else { return }
+
+        let interfaceIdentifiers = Set(attachmentConfigurations.compactMap { $0?.bridgeInterfaceIdentifier })
+        guard !interfaceIdentifiers.isEmpty else { return }
+
+        var context = SCDynamicStoreContext(
+            version: 0,
+            info: Unmanaged.passUnretained(self).toOpaque(),
+            retain: nil,
+            release: nil,
+            copyDescription: nil
+        )
+
+        guard let store = SCDynamicStoreCreate(
+            nil,
+            "VirtualBuddy.VMNetworkAttachmentHelper" as CFString,
+            vmNetworkAttachmentDynamicStoreCallback,
+            &context
+        ) else {
+            logger.error("Failed to create SystemConfiguration dynamic store for bridge monitoring: error=\(SCError())")
+            return
+        }
+
+        let linkKeyPairs = interfaceIdentifiers.map { interfaceIdentifier in
+            let key = Self.linkStateKey(for: interfaceIdentifier)
+            return (key, interfaceIdentifier)
+        }
+        let identifierByKey = Dictionary(uniqueKeysWithValues: linkKeyPairs)
+        let notificationKeys = Array(identifierByKey.keys)
+
+        guard SCDynamicStoreSetNotificationKeys(store, notificationKeys as CFArray, nil) else {
+            logger.error("Failed to register bridge link-state notifications: error=\(SCError())")
+            return
+        }
+
+        let initialLinkStates = Dictionary(uniqueKeysWithValues: interfaceIdentifiers.map {
+            ($0, Self.isLinkActive(interfaceIdentifier: $0, store: store))
+        })
+
+        dynamicStore = store
+        interfaceIdentifierByLinkKey = identifierByKey
+        interfaceLinkStates = initialLinkStates
+
+        guard SCDynamicStoreSetDispatchQueue(store, .main) else {
+            logger.error("Failed to schedule bridge link-state notifications: error=\(SCError())")
+            stopMonitoringHostInterfaces()
+            return
+        }
+
+        let monitoredInterfaces = interfaceIdentifiers.sorted().joined(separator: ", ")
+        logger.info("Monitoring host link state for bridged interface(s): \(monitoredInterfaces, privacy: .public)")
+    }
+
+    func stop() {
+        cancelRecoveryTasks()
+        stopMonitoringHostInterfaces()
+    }
+
+    func reconnectAll() throws {
+        var scheduledDeviceCount = 0
+
+        for deviceIndex in virtualMachine.networkDevices.indices {
+            guard attachmentConfigurations.indices.contains(deviceIndex),
+                  attachmentConfigurations[deviceIndex] != nil
+            else { continue }
+
+            scheduleRecovery(
+                forDeviceAt: deviceIndex,
+                replacingCurrentAttachment: true,
+                initialDelay: 0,
+                reason: .manualRequest
+            )
+            scheduledDeviceCount += 1
+        }
+
+        guard scheduledDeviceCount > 0 else {
+            throw Failure("This virtual machine has no network attachments that can be reconnected.")
+        }
+
+        logger.info("Manual network reconnection scheduled for \(scheduledDeviceCount) device(s)")
+    }
+
+    func attachmentWasDisconnected(
+        in virtualMachine: VZVirtualMachine,
+        networkDevice: VZNetworkDevice,
+        error: Error
+    ) {
+        let nsError = error as NSError
+        let attachmentDescription = String(describing: networkDevice.attachment)
+
+        guard self.virtualMachine === virtualMachine else {
+            logger.info("Ignoring network disconnection from a stale VM instance")
+            return
+        }
+
+        guard let deviceIndex = virtualMachine.networkDevices.firstIndex(where: { $0 === networkDevice }) else {
+            logger.error("A network attachment disconnected but its device is not part of the VM: domain=\(nsError.domain, privacy: .public) code=\(nsError.code) error=\(nsError.localizedDescription, privacy: .public) userInfo=\(String(describing: nsError.userInfo), privacy: .public) attachment=\(attachmentDescription, privacy: .public)")
+            return
+        }
+
+        let macAddress = attachmentConfigurations.indices.contains(deviceIndex)
+            ? attachmentConfigurations[deviceIndex]?.macAddress ?? "unknown"
+            : "unknown"
+
+        logger.error("Network attachment disconnected: device=\(deviceIndex) MAC=\(macAddress, privacy: .public) domain=\(nsError.domain, privacy: .public) code=\(nsError.code) error=\(nsError.localizedDescription, privacy: .public) userInfo=\(String(describing: nsError.userInfo), privacy: .public) attachment=\(attachmentDescription, privacy: .public)")
+
+        guard attachmentConfigurations.indices.contains(deviceIndex),
+              attachmentConfigurations[deviceIndex] != nil
+        else {
+            logger.error("No recovery configuration is available for network device \(deviceIndex)")
+            return
+        }
+
+        guard recoveryTasks[deviceIndex] == nil else {
+            logger.debug("Network recovery is already active for device \(deviceIndex)")
+            return
+        }
+
+        scheduleRecovery(
+            forDeviceAt: deviceIndex,
+            replacingCurrentAttachment: false,
+            initialDelay: Self.recoveryDelays[0],
+            reason: .attachmentDisconnected
+        )
+    }
+
+    fileprivate func dynamicStoreDidChange(_ changedKeys: [String]) {
+        guard let store = dynamicStore else { return }
+
+        for key in Set(changedKeys) {
+            guard let interfaceIdentifier = interfaceIdentifierByLinkKey[key] else { continue }
+
+            let wasActive = interfaceLinkStates[interfaceIdentifier]
+            let isActive = Self.isLinkActive(interfaceIdentifier: interfaceIdentifier, store: store)
+            interfaceLinkStates[interfaceIdentifier] = isActive
+
+            logger.debug("Host bridge interface \(interfaceIdentifier, privacy: .public) link state changed: active=\(isActive)")
+
+            guard wasActive == false, isActive else { continue }
+
+            handleHostInterfaceBecameActive(interfaceIdentifier)
+        }
+    }
+
+    private func handleHostInterfaceBecameActive(_ interfaceIdentifier: String) {
+        let deviceIndices = attachmentConfigurations.indices.filter {
+            attachmentConfigurations[$0]?.bridgeInterfaceIdentifier == interfaceIdentifier
+        }
+
+        guard !deviceIndices.isEmpty else { return }
+
+        logger.info("Host bridge interface \(interfaceIdentifier, privacy: .public) became active; scheduling attachment replacement for \(deviceIndices.count) device(s)")
+
+        for deviceIndex in deviceIndices {
+            scheduleRecovery(
+                forDeviceAt: deviceIndex,
+                replacingCurrentAttachment: true,
+                initialDelay: Self.hostInterfaceDebounceDelay,
+                reason: .hostInterfaceBecameActive
+            )
+        }
+    }
+
+    private func scheduleRecovery(
+        forDeviceAt deviceIndex: Int,
+        replacingCurrentAttachment: Bool,
+        initialDelay: TimeInterval,
+        reason: RecoveryReason
+    ) {
+        guard virtualMachine.networkDevices.indices.contains(deviceIndex),
+              attachmentConfigurations.indices.contains(deviceIndex),
+              let attachmentConfiguration = attachmentConfigurations[deviceIndex]
+        else {
+            logger.error("Unable to schedule recovery for network device \(deviceIndex): recovery configuration is unavailable")
+            return
+        }
+
+        if let existingTask = recoveryTasks.removeValue(forKey: deviceIndex) {
+            existingTask.task.cancel()
+        }
+
+        let networkDevice = virtualMachine.networkDevices[deviceIndex]
+        let taskID = UUID()
+
+        let task = Task { @MainActor [weak self, weak virtualMachine, weak networkDevice] in
+            var attempt = 0
+            var shouldReplaceCurrentAttachment = replacingCurrentAttachment
+            var nextDelay = initialDelay
+
+            defer {
+                self?.recoveryDidFinish(forDeviceAt: deviceIndex, taskID: taskID)
+            }
+
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(nextDelay))
+                } catch {
+                    return
+                }
+
+                guard let self, let virtualMachine, let networkDevice,
+                      self.virtualMachine === virtualMachine
+                else { return }
+
+                if networkDevice.attachment != nil && !shouldReplaceCurrentAttachment {
+                    self.logger.info("Network device \(deviceIndex) recovered before retry was necessary")
+                    return
+                }
+
+                shouldReplaceCurrentAttachment = false
+                attempt += 1
+
+                self.logger.info("Attempting to reconnect network device \(deviceIndex) (\(attachmentConfiguration.description, privacy: .public), MAC=\(attachmentConfiguration.macAddress, privacy: .public), reason=\(reason.rawValue, privacy: .public), attempt=\(attempt))")
+
+                do {
+                    let newAttachment = try attachmentConfiguration.makeAttachment()
+                    networkDevice.attachment = newAttachment
+
+                    self.logger.debug("Assigned new attachment to network device \(deviceIndex): \(String(describing: newAttachment), privacy: .public)")
+
+                    try await Task.sleep(for: .seconds(Self.attachmentStabilizationDelay))
+
+                    guard self.virtualMachine === virtualMachine else { return }
+
+                    if networkDevice.attachment != nil {
+                        self.logger.info("Successfully reconnected network device \(deviceIndex) (\(attachmentConfiguration.description, privacy: .public), MAC=\(attachmentConfiguration.macAddress, privacy: .public))")
+                        return
+                    }
+
+                    self.logger.error("Network device \(deviceIndex) rejected the replacement attachment; retrying")
+                } catch is CancellationError {
+                    return
+                } catch {
+                    self.logger.error("Failed to reconnect network device \(deviceIndex) on attempt \(attempt): \(error, privacy: .public)")
+                }
+
+                let delayIndex = min(attempt, Self.recoveryDelays.count - 1)
+                nextDelay = Self.recoveryDelays[delayIndex]
+            }
+        }
+
+        recoveryTasks[deviceIndex] = RecoveryTask(id: taskID, task: task)
+    }
+
+    private func recoveryDidFinish(forDeviceAt deviceIndex: Int, taskID: UUID) {
+        guard recoveryTasks[deviceIndex]?.id == taskID else { return }
+
+        recoveryTasks.removeValue(forKey: deviceIndex)
+    }
+
+    private func cancelRecoveryTasks() {
+        recoveryTasks.values.forEach { $0.task.cancel() }
+        recoveryTasks.removeAll()
+    }
+
+    private func stopMonitoringHostInterfaces() {
+        if let dynamicStore {
+            SCDynamicStoreSetDispatchQueue(dynamicStore, nil)
+        }
+
+        dynamicStore = nil
+        interfaceIdentifierByLinkKey.removeAll()
+        interfaceLinkStates.removeAll()
+    }
+
+    private static func linkStateKey(for interfaceIdentifier: String) -> String {
+        SCDynamicStoreKeyCreateNetworkInterfaceEntity(
+            nil,
+            kSCDynamicStoreDomainState,
+            interfaceIdentifier as CFString,
+            kSCEntNetLink
+        ) as String
+    }
+
+    private static func isLinkActive(
+        interfaceIdentifier: String,
+        store: SCDynamicStore
+    ) -> Bool {
+        let key = linkStateKey(for: interfaceIdentifier)
+
+        guard let linkState = SCDynamicStoreCopyValue(store, key as CFString) as? [String: Any] else {
+            return false
+        }
+
+        return linkState[kSCPropNetLinkActive as String] as? Bool == true
+    }
+}

--- a/VirtualCore/Source/Virtualization/VMNetworkAttachmentHelper.swift
+++ b/VirtualCore/Source/Virtualization/VMNetworkAttachmentHelper.swift
@@ -25,7 +25,7 @@ final class VMNetworkAttachmentHelper {
             case bridge(interfaceIdentifier: String)
         }
 
-        let kind: Kind
+        var kind: Kind
         let macAddress: String
 
         var bridgeInterfaceIdentifier: String? {
@@ -65,6 +65,7 @@ final class VMNetworkAttachmentHelper {
 
     private enum RecoveryReason: String {
         case attachmentDisconnected
+        case bridgeInterfaceChanged
         case hostInterfaceBecameActive
         case manualRequest
     }
@@ -75,7 +76,7 @@ final class VMNetworkAttachmentHelper {
 
     private let virtualMachine: VZVirtualMachine
     private let logger: Logger
-    private let attachmentConfigurations: [AttachmentConfiguration?]
+    private var attachmentConfigurations: [AttachmentConfiguration?]
 
     private var recoveryTasks: [Int: RecoveryTask] = [:]
 
@@ -200,6 +201,51 @@ final class VMNetworkAttachmentHelper {
         }
 
         logger.info("Manual network reconnection scheduled for \(scheduledDeviceCount) device(s)")
+    }
+
+    var bridgeInterfaceIdentifiers: Set<String> {
+        Set(attachmentConfigurations.compactMap { $0?.bridgeInterfaceIdentifier })
+    }
+
+    var hasBridgedAttachments: Bool {
+        !bridgeInterfaceIdentifiers.isEmpty
+    }
+
+    func changeBridgeInterface(to interfaceIdentifier: String) throws {
+        guard VZBridgedNetworkInterface.networkInterfaces.contains(where: {
+            $0.identifier == interfaceIdentifier
+        }) else {
+            throw Failure("The bridged network interface \(interfaceIdentifier.quoted) is not currently available.")
+        }
+
+        let bridgedDeviceIndices = attachmentConfigurations.indices.filter {
+            attachmentConfigurations[$0]?.bridgeInterfaceIdentifier != nil
+        }
+
+        guard !bridgedDeviceIndices.isEmpty else {
+            throw Failure("This virtual machine has no bridged network attachments.")
+        }
+
+        for deviceIndex in bridgedDeviceIndices {
+            guard var configuration = attachmentConfigurations[deviceIndex] else { continue }
+
+            configuration.kind = .bridge(interfaceIdentifier: interfaceIdentifier)
+            attachmentConfigurations[deviceIndex] = configuration
+        }
+
+        stopMonitoringHostInterfaces()
+        startMonitoringHostInterfaces()
+
+        for deviceIndex in bridgedDeviceIndices {
+            scheduleRecovery(
+                forDeviceAt: deviceIndex,
+                replacingCurrentAttachment: true,
+                initialDelay: 0,
+                reason: .bridgeInterfaceChanged
+            )
+        }
+
+        logger.info("Changed \(bridgedDeviceIndices.count) bridged network device(s) to host interface \(interfaceIdentifier, privacy: .public)")
     }
 
     func attachmentWasDisconnected(

--- a/VirtualUI/Source/Session/VirtualMachineSessionUI.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionUI.swift
@@ -108,17 +108,6 @@ public struct VirtualMachineWindowCommands: View {
                 focusedSession?.resizeWindow.send(.fitScreen)
             }
             .keyboardShortcut("3", modifiers: .command)
-
-            Divider()
-
-            if let controller = focusedSession?.controller {
-                VirtualMachineNetworkCommands(controller: controller)
-            } else {
-                Menu("Network") {
-                    Button("Reconnect") { }
-                }
-                .disabled(true)
-            }
         }
         .disabled(focusedSession == nil)
         .onReceive(manager.focusedSessionChanged) { ref in
@@ -134,15 +123,128 @@ public struct VirtualMachineWindowCommands: View {
 
 }
 
+public struct VirtualMachineGuestCommands: View {
+    @EnvironmentObject private var manager: VirtualMachineSessionUIManager
+
+    @State private var focusedSessionReference: WeakReference<VirtualMachineSessionUI>?
+    private var focusedSession: VirtualMachineSessionUI? { focusedSessionReference?.object }
+
+    public init() { }
+
+    public var body: some View {
+        Group {
+            if let controller = focusedSession?.controller {
+                VirtualMachineGuestActions(controller: controller)
+            } else {
+                /// Dummy item for when session is not available.
+                Button {
+                } label: {
+                    Label("Start", systemImage: "play.fill")
+                }
+            }
+        }
+        .disabled(focusedSession == nil)
+        .onReceive(manager.focusedSessionChanged) { ref in
+            focusedSessionReference = ref
+        }
+    }
+}
+
+private struct VirtualMachineGuestActions: View {
+    @ObservedObject var controller: VMController
+
+    @State private var actionTask: Task<Void, Never>?
+
+    var body: some View {
+        Group {
+            if controller.state.isRunning {
+                stopButton
+                    .modifier { button in
+                        if #available(macOS 15.0, *) {
+                            button.modifierKeyAlternate(.option) {
+                                forceStopButton
+                            }
+                        } else {
+                            button
+                        }
+                    }
+            } else {
+                Button {
+                    runGuestAction {
+                        if controller.canResume {
+                            try await controller.resume()
+                        } else {
+                            try await controller.start()
+                        }
+                    }
+                } label: {
+                    Label("Start", systemImage: "play.fill")
+                }
+                .keyboardShortcut("r", modifiers: .command)
+                .disabled(actionTask != nil || !(controller.canStart || controller.canResume))
+            }
+
+            Button {
+                runGuestAction {
+                    try await controller.pause()
+                }
+            } label: {
+                Label("Pause", systemImage: "pause.fill")
+            }
+            .disabled(actionTask != nil || !controller.canPause)
+
+            Divider()
+
+            VirtualMachineNetworkCommands(controller: controller)
+        }
+    }
+
+    private var stopButton: some View {
+        Button {
+            runGuestAction {
+                try await controller.stop()
+            }
+        } label: {
+            Label("Stop", systemImage: "stop.fill")
+        }
+        .disabled(actionTask != nil)
+    }
+
+    private var forceStopButton: some View {
+        Button {
+            runGuestAction {
+                try await controller.forceStop()
+            }
+        } label: {
+            Label("Force Stop", systemImage: "stop.circle.fill")
+        }
+        .disabled(actionTask != nil)
+    }
+
+    private func runGuestAction(_ action: @escaping @MainActor () async throws -> Void) {
+        actionTask = Task { @MainActor in
+            defer { actionTask = nil }
+
+            do {
+                try await action()
+            } catch {
+                NSApp.presentError(error)
+            }
+        }
+    }
+}
+
 private struct VirtualMachineNetworkCommands: View {
     @ObservedObject var controller: VMController
 
     var body: some View {
-        Menu("Network") {
-            Button("Reconnect") {
+        Menu {
+            Button {
                 performNetworkAction {
                     try controller.reconnectNetwork()
                 }
+            } label: {
+                Label("Reconnect", systemImage: "arrow.clockwise")
             }
             .disabled(!controller.canReconnectNetwork)
 
@@ -151,8 +253,11 @@ private struct VirtualMachineNetworkCommands: View {
             let availableInterfaces = controller.availableBridgeInterfaces
 
             if availableInterfaces.isEmpty {
-                Button("No Host Interfaces Available") { }
-                    .disabled(true)
+                Button {
+                } label: {
+                    Label("No Host Interfaces Available", systemImage: "network.slash")
+                }
+                .disabled(true)
             } else {
                 ForEach(availableInterfaces) { interface in
                     Button {
@@ -160,15 +265,16 @@ private struct VirtualMachineNetworkCommands: View {
                             try controller.changeBridgeInterface(to: interface.id)
                         }
                     } label: {
-                        if isActive(interface) {
-                            Label(interfaceDisplayName(interface), systemImage: "checkmark")
-                        } else {
-                            Text(interfaceDisplayName(interface))
-                        }
+                        Label(
+                            interfaceDisplayName(interface),
+                            systemImage: isActive(interface) ? "checkmark" : "network"
+                        )
                     }
                     .disabled(!controller.canChangeBridgeInterface || isActive(interface))
                 }
             }
+        } label: {
+            Label("Network", systemImage: "network")
         }
     }
 
@@ -185,7 +291,7 @@ private struct VirtualMachineNetworkCommands: View {
         do {
             try action()
         } catch {
-            NSAlert(error: error).runModal()
+            NSApp.presentError(error)
         }
     }
 }

--- a/VirtualUI/Source/Session/VirtualMachineSessionUI.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionUI.swift
@@ -108,6 +108,15 @@ public struct VirtualMachineWindowCommands: View {
                 focusedSession?.resizeWindow.send(.fitScreen)
             }
             .keyboardShortcut("3", modifiers: .command)
+
+            Divider()
+
+            if let controller = focusedSession?.controller {
+                ReconnectNetworkCommand(controller: controller)
+            } else {
+                Button("Reconnect Network") { }
+                    .disabled(true)
+            }
         }
         .disabled(focusedSession == nil)
         .onReceive(manager.focusedSessionChanged) { ref in
@@ -121,4 +130,19 @@ public struct VirtualMachineWindowCommands: View {
         Divider()
     }
 
+}
+
+private struct ReconnectNetworkCommand: View {
+    @ObservedObject var controller: VMController
+
+    var body: some View {
+        Button("Reconnect Network") {
+            do {
+                try controller.reconnectNetwork()
+            } catch {
+                NSAlert(error: error).runModal()
+            }
+        }
+        .disabled(!controller.canReconnectNetwork)
+    }
 }

--- a/VirtualUI/Source/Session/VirtualMachineSessionUI.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionUI.swift
@@ -112,10 +112,12 @@ public struct VirtualMachineWindowCommands: View {
             Divider()
 
             if let controller = focusedSession?.controller {
-                ReconnectNetworkCommand(controller: controller)
+                VirtualMachineNetworkCommands(controller: controller)
             } else {
-                Button("Reconnect Network") { }
-                    .disabled(true)
+                Menu("Network") {
+                    Button("Reconnect") { }
+                }
+                .disabled(true)
             }
         }
         .disabled(focusedSession == nil)
@@ -132,17 +134,58 @@ public struct VirtualMachineWindowCommands: View {
 
 }
 
-private struct ReconnectNetworkCommand: View {
+private struct VirtualMachineNetworkCommands: View {
     @ObservedObject var controller: VMController
 
     var body: some View {
-        Button("Reconnect Network") {
-            do {
-                try controller.reconnectNetwork()
-            } catch {
-                NSAlert(error: error).runModal()
+        Menu("Network") {
+            Button("Reconnect") {
+                performNetworkAction {
+                    try controller.reconnectNetwork()
+                }
+            }
+            .disabled(!controller.canReconnectNetwork)
+
+            Divider()
+
+            let availableInterfaces = controller.availableBridgeInterfaces
+
+            if availableInterfaces.isEmpty {
+                Button("No Host Interfaces Available") { }
+                    .disabled(true)
+            } else {
+                ForEach(availableInterfaces) { interface in
+                    Button {
+                        performNetworkAction {
+                            try controller.changeBridgeInterface(to: interface.id)
+                        }
+                    } label: {
+                        if isActive(interface) {
+                            Label(interfaceDisplayName(interface), systemImage: "checkmark")
+                        } else {
+                            Text(interfaceDisplayName(interface))
+                        }
+                    }
+                    .disabled(!controller.canChangeBridgeInterface || isActive(interface))
+                }
             }
         }
-        .disabled(!controller.canReconnectNetwork)
+    }
+
+    private func isActive(_ interface: VBNetworkDeviceInterface) -> Bool {
+        controller.activeBridgeInterfaceIdentifiers == [interface.id]
+    }
+
+    private func interfaceDisplayName(_ interface: VBNetworkDeviceInterface) -> String {
+        guard interface.name != interface.id else { return interface.name }
+        return "\(interface.name) (\(interface.id))"
+    }
+
+    private func performNetworkAction(_ action: () throws -> Void) {
+        do {
+            try action()
+        } catch {
+            NSAlert(error: error).runModal()
+        }
     }
 }


### PR DESCRIPTION
- Monitor the host's selected bridge interface and reattach it to the guest when the interface becomes available after being disconnected
- Add new "Guest" main menu item with common guest operations and the new "Network" menu with options to reconnect the bridge interface or choose another interface to use for the current virtual machine session