### PR TITLE
Fix collapsed pre-boot options form on modern macOS

### DIFF
--- a/VirtualUI/Source/Components/SelfSizingGroupedForm.swift
+++ b/VirtualUI/Source/Components/SelfSizingGroupedForm.swift
@@ -13,11 +13,32 @@ struct SelfSizingGroupedForm<Content: View>: View {
 
     var body: some View {
         ZStack {
-            Form {
-                content()
+            form
+        }
+        .frame(height: max(minHeight, contentHeight))
+    }
+
+    @ViewBuilder
+    private var form: some View {
+        let form = Form {
+            content()
+        }
+        .formStyle(.grouped)
+
+        if #available(macOS 15.0, *) {
+            form.onScrollGeometryChange(for: CGFloat.self) { geometry in
+                geometry.contentSize.height
+            } action: { _, newHeight in
+                guard !disabled else { return }
+                guard newHeight != contentHeight else { return }
+                guard newHeight > 0, newHeight.isFinite else { return }
+                contentHeight = newHeight
             }
-            .formStyle(.grouped)
-            .introspect(.scrollView, on: .macOS(.v13, .v14, .v15, .v26, .v27)) { scrollView in
+        } else {
+            /// The grouped `Form` is no longer backed by an introspectable `NSScrollView`
+            /// on modern macOS, so introspection is only used where the native
+            /// scroll geometry API is unavailable.
+            form.introspect(.scrollView, on: .macOS(.v13, .v14)) { scrollView in
                 guard !disabled else { return }
                 guard let frame = scrollView.documentView?.frame else { return }
                 guard frame.height != contentHeight else { return }
@@ -28,7 +49,6 @@ struct SelfSizingGroupedForm<Content: View>: View {
                 }
             }
         }
-        .frame(height: max(minHeight, contentHeight))
     }
 }
 


### PR DESCRIPTION
## Problem

On recent macOS releases (observed on macOS 27.0 beta, 26A5388g), the options panel on a VM window's pre-boot screen collapses to its 100 pt minimum height. Only the first two rows are visible in a tiny scroll area, which hides the remaining rows — including the "Virtual Machine Settings…" button — well enough that it looks like post-install configuration doesn't exist.

## Cause

`SelfSizingGroupedForm` sizes the grouped `Form` by introspecting the backing `NSScrollView`'s `documentView` frame via SwiftUIIntrospect. On modern macOS the grouped form is no longer backed by an introspectable `NSScrollView`, so the measurement closure never fires, `contentHeight` stays `0`, and the frame falls back to `minHeight`.

## Fix

Use the native `onScrollGeometryChange` API (macOS 15+) to observe the form's scroll content height, keeping the introspection path only for macOS 13/14 (deployment target is 14.0). Same guards and behavior as before, including the `VBDisableSelfSizingGroupedForm` defaults escape hatch.

## Testing

- Built and ran on macOS 27.0 beta with Xcode 27 beta: the pre-boot panel now fits all rows (saved-state picker, recovery/DFU toggles, capture-keys toggle, Settings button) with no inner scrolling.
- `VBDisableSelfSizingGroupedForm` still pins the form to `minHeight` when set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
