### PR TITLE
Fix configure option disabled state not updating correctly

### DIFF
--- a/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionUIManager.swift
@@ -14,7 +14,7 @@ public final class VirtualMachineSessionUIManager: ObservableObject {
 
     private let openWindow = OpenCocoaWindowAction.default
 
-    private var sessions = [VBVirtualMachine.ID: VirtualMachineSessionUI]()
+    @Published private(set) var sessions = [VBVirtualMachine.ID: VirtualMachineSessionUI]()
 
     private init() { }
 


### PR DESCRIPTION
This makes the `sessions` property on `VirtualMachineSessionUIManager` `@Published` so that the enabled state for the new "Configure…" context menu option in the library view (introduced in #726) updates correctly.