### PR TITLE
Replace unsafe HTTP response casts with safe handling

### DIFF
--- a/VirtualCore/Source/GuestSupport/GuestAdditionsDiskImage.swift
+++ b/VirtualCore/Source/GuestSupport/GuestAdditionsDiskImage.swift
@@ -121,7 +121,11 @@ public final class GuestAdditionsDiskImage: ObservableObject {
         let request = URLRequest(url: app.url)
         let (fileURL, response) = try await URLSession.shared.download(for: request)
 
-        let status = (response as! HTTPURLResponse).statusCode
+        guard let response = response as? HTTPURLResponse else {
+            throw Failure("Expected HTTPURLResponse while downloading guest app image")
+        }
+
+        let status = response.statusCode
         try (status == 200).require("HTTP \(status).")
 
         await MainActor.run { self.state = .installing }

--- a/VirtualCore/Source/Restore Images/VBAPIClient.swift
+++ b/VirtualCore/Source/Restore Images/VBAPIClient.swift
@@ -133,7 +133,11 @@ public final class VBAPIClient {
 
         let (data, res) = try await URLSession.shared.data(for: req)
 
-        let code = (res as! HTTPURLResponse).statusCode
+        guard let response = res as? HTTPURLResponse else {
+            throw "Unexpected non-HTTP response while fetching restore catalog"
+        }
+
+        let code = response.statusCode
 
         guard code == 200 else {
             throw "HTTP \(code)"
@@ -189,7 +193,11 @@ public final class VBAPIClient {
 
             let (data, res) = try await URLSession.shared.data(for: req)
 
-            let code = (res as! HTTPURLResponse).statusCode
+            guard let response = res as? HTTPURLResponse else {
+                throw "Unexpected non-HTTP response while fetching signing status"
+            }
+
+            let code = response.statusCode
 
             guard code == 200 else {
                 throw "HTTP \(code)"


### PR DESCRIPTION
This PR replaces unsafe forced casts of HTTP responses with safe Swift casting.

Changes:
- Replaced `as! HTTPURLResponse` with safe `as?` handling
- Added error paths for unexpected non-HTTP responses
- Prevented possible runtime crashes without changing normal behavior