### PR TITLE
fix(resize): handle raw disk GPT gaps

### DIFF
--- a/VirtualCore/Source/Utilities/VBDiskResizer.swift
+++ b/VirtualCore/Source/Utilities/VBDiskResizer.swift
@@ -284,22 +284,20 @@ public struct VBDiskResizer {
             }
 
             guard totalSectors > 41 else {
-                logger.debug("Disk is too small for GPT relocation; leaving partition table for the guest to adjust")
-                return .notApplicable
+                throw VBDiskResizeError.systemCommandFailed("Disk is too small for GPT relocation", -1)
             }
             let newBackupLBA = totalSectors - 1
             let backupEntriesLBA = newBackupLBA - 32
             let newLastUsable = backupEntriesLBA - 8
             let (requiredLastUsable, requiredLastUsableOverflow) = trailingGap.addingReportingOverflow(recoveryLength - 1)
             guard !requiredLastUsableOverflow, newLastUsable >= requiredLastUsable else {
-                logger.debug("Disk has no room for the recovery partition; leaving partition table for the guest to adjust")
-                return .notApplicable
+                throw VBDiskResizeError.systemCommandFailed("Disk has no room for the recovery partition", -1)
             }
             let newRecoveryLast = newLastUsable - trailingGap
             let newRecoveryFirst = newRecoveryLast - (recoveryLength - 1)
 
             guard newRecoveryFirst > 0 else {
-                return .notApplicable
+                throw VBDiskResizeError.systemCommandFailed("Invalid relocated recovery partition", -1)
             }
 
             let newMainLast = newRecoveryFirst - 1

--- a/VirtualCore/Source/Utilities/VBDiskResizer.swift
+++ b/VirtualCore/Source/Utilities/VBDiskResizer.swift
@@ -107,7 +107,7 @@ public struct VBDiskResizer {
                 try fileHandle.synchronize()
             }
 
-            try GPTLayoutAdjuster(imageURL: temporaryURL, newSize: newSize).perform()
+            _ = try GPTLayoutAdjuster(imageURL: temporaryURL, newSize: newSize).perform()
 
             guard rename(temporaryURL.path, imageURL.path) == 0 else {
                 throw VBDiskResizeError.systemCommandFailed("rename", errno)
@@ -171,6 +171,12 @@ public struct VBDiskResizer {
     /// If the image doesn't contain the expected macOS layout (main APFS container followed by
     /// a recovery partition), this is a no-op: the guest OS can claim the space by itself.
     private struct GPTLayoutAdjuster {
+        enum Outcome {
+            case notApplicable
+            case unchanged
+            case adjusted
+        }
+
         let imageURL: URL
         let newSize: UInt64
 
@@ -178,7 +184,7 @@ public struct VBDiskResizer {
         private let mainContainerGUID = UUID(uuidString: "7C3457EF-0000-11AA-AA11-00306543ECAC")!
         private let recoveryGUID = UUID(uuidString: "52637672-7900-11AA-AA11-00306543ECAC")!
 
-        func perform() throws {
+        func perform() throws -> Outcome {
             guard newSize % sectorSize == 0 else {
                 throw VBDiskResizeError.systemCommandFailed("New disk size must be 512-byte aligned", -1)
             }
@@ -217,21 +223,21 @@ public struct VBDiskResizer {
                 let entriesLengthInt = Int(exactly: entriesLength)
             else {
                 logger.debug("No valid GPT header; leaving partition table for the guest to adjust")
-                return
+                return .notApplicable
             }
 
             var headerForCRC = Data(headerData.prefix(Int(header.headerSize)))
             writeUInt32LittleEndian(&headerForCRC, offset: 16, value: 0)
             guard crc32(of: headerForCRC) == header.headerCRC32 else {
                 logger.debug("GPT header checksum is invalid; leaving partition table for the guest to adjust")
-                return
+                return .notApplicable
             }
 
             try fileHandle.seek(toOffset: entriesOffset)
             var entries = try readExactly(fileHandle: fileHandle, length: entriesLengthInt)
             guard crc32(of: entries) == header.partitionEntriesCRC32 else {
                 logger.debug("GPT partition table checksum is invalid; leaving partition table for the guest to adjust")
-                return
+                return .notApplicable
             }
 
             guard
@@ -239,7 +245,7 @@ public struct VBDiskResizer {
                 let recoveryIndex = findPartitionIndex(in: entries, guid: recoveryGUID, entrySize: Int(header.entrySize), preferLargest: false)
             else {
                 logger.debug("No macOS APFS + recovery layout in GPT; leaving partition table for the guest to adjust")
-                return
+                return .notApplicable
             }
 
             let mainFirst = readUInt64LittleEndian(from: entries, offset: mainIndex * Int(header.entrySize) + 32)
@@ -252,39 +258,55 @@ public struct VBDiskResizer {
                 mainFirst <= mainLast,
                 mainLast < recoveryFirst,
                 recoveryFirst <= recoveryLast,
-                recoveryLast == header.lastUsableLBA
+                recoveryLast <= header.lastUsableLBA
             else {
-                logger.debug("Unexpected macOS GPT geometry; leaving partition table for the guest to adjust")
-                return
+                throw VBDiskResizeError.systemCommandFailed("Unexpected macOS GPT geometry", -1)
             }
 
+            let trailingGap = header.lastUsableLBA - recoveryLast
             let recoveryLength = recoveryLast - recoveryFirst + 1
+
+            for index in 0..<(entries.count / Int(header.entrySize)) {
+                let offset = index * Int(header.entrySize)
+                let type = entries[offset..<(offset + 16)]
+                guard type.contains(where: { $0 != 0 }) else { continue }
+
+                let first = readUInt64LittleEndian(from: entries, offset: offset + 32)
+                let last = readUInt64LittleEndian(from: entries, offset: offset + 40)
+                guard
+                    first >= header.firstUsableLBA,
+                    first <= last,
+                    last <= header.lastUsableLBA,
+                    index == mainIndex || index == recoveryIndex || last < mainFirst
+                else {
+                    throw VBDiskResizeError.systemCommandFailed("Unexpected macOS GPT geometry", -1)
+                }
+            }
 
             guard totalSectors > 41 else {
                 logger.debug("Disk is too small for GPT relocation; leaving partition table for the guest to adjust")
-                return
+                return .notApplicable
             }
             let newBackupLBA = totalSectors - 1
             let backupEntriesLBA = newBackupLBA - 32
-            var newLastUsable = backupEntriesLBA - 8
-            guard newLastUsable >= recoveryLength - 1 else {
+            let newLastUsable = backupEntriesLBA - 8
+            let (requiredLastUsable, requiredLastUsableOverflow) = trailingGap.addingReportingOverflow(recoveryLength - 1)
+            guard !requiredLastUsableOverflow, newLastUsable >= requiredLastUsable else {
                 logger.debug("Disk has no room for the recovery partition; leaving partition table for the guest to adjust")
-                return
+                return .notApplicable
             }
-            var newRecoveryFirst = newLastUsable - (recoveryLength - 1)
+            let newRecoveryLast = newLastUsable - trailingGap
+            let newRecoveryFirst = newRecoveryLast - (recoveryLength - 1)
 
-            let alignment: UInt64 = 8
-            let remainder = newRecoveryFirst % alignment
-            if remainder != 0 {
-                newRecoveryFirst -= remainder
-                newLastUsable = newRecoveryFirst + recoveryLength - 1
+            guard newRecoveryFirst > 0 else {
+                return .notApplicable
             }
 
             let newMainLast = newRecoveryFirst - 1
 
             guard newRecoveryFirst > recoveryFirst, newMainLast > mainLast else {
                 // Nothing to do if the main container already occupies the space
-                return
+                return .unchanged
             }
 
             try copySectors(
@@ -310,7 +332,7 @@ public struct VBDiskResizer {
             writeUInt64LittleEndian(
                 &entries,
                 offset: recoveryIndex * Int(header.entrySize) + 40,
-                value: newLastUsable
+                value: newRecoveryLast
             )
 
             header.backupLBA = newBackupLBA
@@ -334,6 +356,23 @@ public struct VBDiskResizer {
 
             try fileHandle.synchronize()
 
+            try verify(
+                fileHandle: fileHandle,
+                headerOffset: headerOffset,
+                entriesOffset: entriesOffset,
+                entriesLength: entriesLengthInt,
+                backupLBA: newBackupLBA,
+                lastUsableLBA: newLastUsable,
+                entriesCRC32: header.partitionEntriesCRC32,
+                mainIndex: mainIndex,
+                mainLast: newMainLast,
+                recoveryIndex: recoveryIndex,
+                recoveryFirst: newRecoveryFirst,
+                recoveryLast: newRecoveryLast,
+                trailingGap: trailingGap,
+                entrySize: Int(header.entrySize)
+            )
+
             try zeroSectors(
                 fileHandle: fileHandle,
                 start: recoveryFirst,
@@ -342,6 +381,41 @@ public struct VBDiskResizer {
             )
 
             try fileHandle.synchronize()
+            return .adjusted
+        }
+
+        private func verify(
+            fileHandle: FileHandle,
+            headerOffset: UInt64,
+            entriesOffset: UInt64,
+            entriesLength: Int,
+            backupLBA: UInt64,
+            lastUsableLBA: UInt64,
+            entriesCRC32: UInt32,
+            mainIndex: Int,
+            mainLast: UInt64,
+            recoveryIndex: Int,
+            recoveryFirst: UInt64,
+            recoveryLast: UInt64,
+            trailingGap: UInt64,
+            entrySize: Int
+        ) throws {
+            try fileHandle.seek(toOffset: headerOffset)
+            let header = GPTHeader(data: try readExactly(fileHandle: fileHandle, length: Int(sectorSize)))
+            try fileHandle.seek(toOffset: entriesOffset)
+            let entries = try readExactly(fileHandle: fileHandle, length: entriesLength)
+            guard
+                header.backupLBA == backupLBA,
+                header.lastUsableLBA == lastUsableLBA,
+                header.partitionEntriesCRC32 == entriesCRC32,
+                crc32(of: entries) == entriesCRC32,
+                readUInt64LittleEndian(from: entries, offset: mainIndex * entrySize + 40) == mainLast,
+                readUInt64LittleEndian(from: entries, offset: recoveryIndex * entrySize + 32) == recoveryFirst,
+                readUInt64LittleEndian(from: entries, offset: recoveryIndex * entrySize + 40) == recoveryLast,
+                header.lastUsableLBA - recoveryLast == trailingGap
+            else {
+                throw VBDiskResizeError.systemCommandFailed("Failed to verify adjusted GPT", -1)
+            }
         }
 
         private func readExactly(fileHandle: FileHandle, length: Int) throws -> Data {

--- a/VirtualUI/Source/VM Configuration/Sections/Storage/ManagedDiskImageEditor.swift
+++ b/VirtualUI/Source/VM Configuration/Sections/Storage/ManagedDiskImageEditor.swift
@@ -75,6 +75,13 @@ struct ManagedDiskImageEditor: View {
                 if isExistingDiskImage && canResize {
                     Text("This \(image.format.displayName) can be expanded. After resizing, the added space must be claimed inside the guest operating system.")
                         .foregroundColor(.blue)
+
+                    if !image.resizePending {
+                        Button("Retry Disk Resize") {
+                            image.resizePending = true
+                            onSave(image)
+                        }
+                    }
                 }
 
                 if let sizeWarning {

--- a/VirtualWormholeTests/VBDiskResizerTests.swift
+++ b/VirtualWormholeTests/VBDiskResizerTests.swift
@@ -291,7 +291,7 @@ final class VBDiskResizerTests: XCTestCase {
     }
 
     private func readUInt64(_ data: Data, offset: Int) -> UInt64 {
-        data.subdata(in: offset..<(offset + 8)).withUnsafeBytes { $0.load(as: UInt64.self) }.littleEndian
+        data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: offset, as: UInt64.self) }.littleEndian
     }
 
     private func write(_ data: Data, to url: URL, offset: Int) throws {

--- a/VirtualWormholeTests/VBDiskResizerTests.swift
+++ b/VirtualWormholeTests/VBDiskResizerTests.swift
@@ -151,6 +151,8 @@ final class VBDiskResizerTests: XCTestCase {
             recoveryFirst: oldRecoveryFirst,
             recoveryLast: oldRecoveryLast
         ).write(to: url)
+        let originalRecovery = Data(repeating: 0xA5, count: recoverySectors * 512)
+        try write(originalRecovery, to: url, offset: oldRecoveryFirst * 512)
 
         try await VBDiskResizer.resizeDiskImage(
             at: url,
@@ -164,12 +166,44 @@ final class VBDiskResizerTests: XCTestCase {
         let newRecoveryFirst = newRecoveryLast - recoverySectors + 1
         let header = try read(url, offset: 512, count: 512)
         let entries = try read(url, offset: 2 * 512, count: 2 * 128)
+        let backupHeader = try read(url, offset: (newTotalSectors - 1) * 512, count: 512)
+        let backupEntries = try read(url, offset: (newTotalSectors - 33) * 512, count: 2 * 128)
         XCTAssertEqual(readUInt64(header, offset: 32), UInt64(newTotalSectors - 1))
         XCTAssertEqual(readUInt64(header, offset: 48), UInt64(newLastUsable))
         XCTAssertEqual(readUInt64(entries, offset: 40), UInt64(newRecoveryFirst - 1))
         XCTAssertEqual(readUInt64(entries, offset: 160), UInt64(newRecoveryFirst))
         XCTAssertEqual(readUInt64(entries, offset: 168), UInt64(newRecoveryLast))
         XCTAssertEqual(readUInt64(header, offset: 48) - readUInt64(entries, offset: 168), UInt64(trailingGap))
+        XCTAssertEqual(try read(url, offset: newRecoveryFirst * 512, count: originalRecovery.count), originalRecovery)
+        XCTAssertEqual(try read(url, offset: oldRecoveryFirst * 512, count: originalRecovery.count), Data(count: originalRecovery.count))
+        XCTAssertEqual(readUInt64(backupHeader, offset: 24), UInt64(newTotalSectors - 1))
+        XCTAssertEqual(readUInt64(backupHeader, offset: 32), 1)
+        XCTAssertEqual(readUInt64(backupHeader, offset: 72), UInt64(newTotalSectors - 33))
+        XCTAssertEqual(backupEntries, entries)
+    }
+
+    func testRawGrowthRejectsRecognizedDiskTooSmallTransactionally() async throws {
+        let url = temporaryURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let image = makeGPTImage(
+            totalSectors: 41,
+            mainFirst: 34,
+            mainLast: 35,
+            recoveryFirst: 36,
+            recoveryLast: 39,
+            lastUsable: 39
+        )
+        try image.write(to: url)
+
+        do {
+            try await VBDiskResizer.resizeDiskImage(at: url, format: .raw, newSize: UInt64(41 * 512))
+            XCTFail("Expected recognized unsafe GPT geometry to fail")
+        } catch {
+            // Expected.
+        }
+
+        XCTAssertEqual(try Data(contentsOf: url), image)
     }
 
     func testRawGrowthRejectsIntermediateGPTPartitionTransactionally() async throws {
@@ -300,18 +334,20 @@ final class VBDiskResizerTests: XCTestCase {
 
     private func makeGPTImage(
         totalSectors: Int,
+        mainFirst: Int = 40,
         mainLast: Int,
         recoveryFirst: Int,
         recoveryLast: Int,
         entryCount: Int = 2,
-        intermediatePartition: ClosedRange<Int>? = nil
+        intermediatePartition: ClosedRange<Int>? = nil,
+        lastUsable: Int? = nil
     ) -> Data {
         let sectorSize = 512
         var image = Data(count: totalSectors * sectorSize)
         let entryCount = max(entryCount, intermediatePartition == nil ? 2 : 3)
         var entries = Data(count: entryCount * 128)
         writeGPTUUID("7C3457EF-0000-11AA-AA11-00306543ECAC", to: &entries, offset: 0)
-        writeUInt64(40, to: &entries, offset: 32)
+        writeUInt64(UInt64(mainFirst), to: &entries, offset: 32)
         writeUInt64(UInt64(mainLast), to: &entries, offset: 40)
         writeGPTUUID("52637672-7900-11AA-AA11-00306543ECAC", to: &entries, offset: 128)
         writeUInt64(UInt64(recoveryFirst), to: &entries, offset: 160)
@@ -331,7 +367,7 @@ final class VBDiskResizerTests: XCTestCase {
         writeUInt64(UInt64(totalSectors - 1), to: &header, offset: 32)
         let entrySectors = (entryCount * 128 + sectorSize - 1) / sectorSize
         writeUInt64(UInt64(max(34, 2 + entrySectors)), to: &header, offset: 40)
-        writeUInt64(UInt64(totalSectors - 41), to: &header, offset: 48)
+        writeUInt64(UInt64(lastUsable ?? totalSectors - 41), to: &header, offset: 48)
         writeUInt64(2, to: &header, offset: 72)
         writeUInt32(UInt32(entryCount), to: &header, offset: 80)
         writeUInt32(128, to: &header, offset: 84)

--- a/VirtualWormholeTests/VBDiskResizerTests.swift
+++ b/VirtualWormholeTests/VBDiskResizerTests.swift
@@ -134,6 +134,75 @@ final class VBDiskResizerTests: XCTestCase {
         )
     }
 
+    func testRawGrowthPreservesTrailingGPTGap() async throws {
+        let url = temporaryURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let oldTotalSectors = 1_024
+        let growthSectors = 128
+        let trailingGap = 7
+        let recoverySectors = 64
+        let oldLastUsable = oldTotalSectors - 41
+        let oldRecoveryLast = oldLastUsable - trailingGap
+        let oldRecoveryFirst = oldRecoveryLast - recoverySectors + 1
+        try makeGPTImage(
+            totalSectors: oldTotalSectors,
+            mainLast: oldRecoveryFirst - 1,
+            recoveryFirst: oldRecoveryFirst,
+            recoveryLast: oldRecoveryLast
+        ).write(to: url)
+
+        try await VBDiskResizer.resizeDiskImage(
+            at: url,
+            format: .raw,
+            newSize: UInt64((oldTotalSectors + growthSectors) * 512)
+        )
+
+        let newTotalSectors = oldTotalSectors + growthSectors
+        let newLastUsable = newTotalSectors - 41
+        let newRecoveryLast = newLastUsable - trailingGap
+        let newRecoveryFirst = newRecoveryLast - recoverySectors + 1
+        let header = try read(url, offset: 512, count: 512)
+        let entries = try read(url, offset: 2 * 512, count: 2 * 128)
+        XCTAssertEqual(readUInt64(header, offset: 32), UInt64(newTotalSectors - 1))
+        XCTAssertEqual(readUInt64(header, offset: 48), UInt64(newLastUsable))
+        XCTAssertEqual(readUInt64(entries, offset: 40), UInt64(newRecoveryFirst - 1))
+        XCTAssertEqual(readUInt64(entries, offset: 160), UInt64(newRecoveryFirst))
+        XCTAssertEqual(readUInt64(entries, offset: 168), UInt64(newRecoveryLast))
+        XCTAssertEqual(readUInt64(header, offset: 48) - readUInt64(entries, offset: 168), UInt64(trailingGap))
+    }
+
+    func testRawGrowthRejectsIntermediateGPTPartitionTransactionally() async throws {
+        let url = temporaryURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let oldTotalSectors = 1_024
+        let oldLastUsable = oldTotalSectors - 41
+        let recoveryLast = oldLastUsable - 7
+        let recoveryFirst = recoveryLast - 64 + 1
+        let image = makeGPTImage(
+            totalSectors: oldTotalSectors,
+            mainLast: recoveryFirst - 14,
+            recoveryFirst: recoveryFirst,
+            recoveryLast: recoveryLast,
+            intermediatePartition: (recoveryFirst - 13)...(recoveryFirst - 1)
+        )
+        try image.write(to: url)
+
+        do {
+            try await VBDiskResizer.resizeDiskImage(
+                at: url,
+                format: .raw,
+                newSize: UInt64((oldTotalSectors + 128) * 512)
+            )
+            XCTFail("Expected unsafe GPT layout to fail")
+        } catch {
+            // Expected.
+        }
+
+        XCTAssertEqual(try Data(contentsOf: url), image)
+    }
+
     func testCorruptGPTHeaderIsIgnored() async throws {
         try await assertCorruptGPTIsIgnored(at: 512 + 56)
     }
@@ -187,6 +256,10 @@ final class VBDiskResizerTests: XCTestCase {
         return try XCTUnwrap(handle.read(upToCount: count))
     }
 
+    private func readUInt64(_ data: Data, offset: Int) -> UInt64 {
+        data.subdata(in: offset..<(offset + 8)).withUnsafeBytes { $0.load(as: UInt64.self) }.littleEndian
+    }
+
     private func write(_ data: Data, to url: URL, offset: Int) throws {
         let handle = try FileHandle(forWritingTo: url)
         defer { try? handle.close() }
@@ -230,10 +303,12 @@ final class VBDiskResizerTests: XCTestCase {
         mainLast: Int,
         recoveryFirst: Int,
         recoveryLast: Int,
-        entryCount: Int = 2
+        entryCount: Int = 2,
+        intermediatePartition: ClosedRange<Int>? = nil
     ) -> Data {
         let sectorSize = 512
         var image = Data(count: totalSectors * sectorSize)
+        let entryCount = max(entryCount, intermediatePartition == nil ? 2 : 3)
         var entries = Data(count: entryCount * 128)
         writeGPTUUID("7C3457EF-0000-11AA-AA11-00306543ECAC", to: &entries, offset: 0)
         writeUInt64(40, to: &entries, offset: 32)
@@ -241,6 +316,11 @@ final class VBDiskResizerTests: XCTestCase {
         writeGPTUUID("52637672-7900-11AA-AA11-00306543ECAC", to: &entries, offset: 128)
         writeUInt64(UInt64(recoveryFirst), to: &entries, offset: 160)
         writeUInt64(UInt64(recoveryLast), to: &entries, offset: 168)
+        if let intermediatePartition {
+            writeGPTUUID("48465300-0000-11AA-AA11-00306543ECAC", to: &entries, offset: 256)
+            writeUInt64(UInt64(intermediatePartition.lowerBound), to: &entries, offset: 288)
+            writeUInt64(UInt64(intermediatePartition.upperBound), to: &entries, offset: 296)
+        }
         image.replaceSubrange((2 * sectorSize)..<(2 * sectorSize + entries.count), with: entries)
 
         var header = Data(count: sectorSize)


### PR DESCRIPTION
## Summary

- Preserve trailing unused GPT sectors when relocating the recovery partition and extending the APFS container entry.
- Reject recognized APFS and recovery layouts when their geometry is unsafe, preventing a silent resize success.
- Verify GPT relocation postconditions before replacing the original image.
- Add a Retry Disk Resize action for images whose host file has already grown.

## Root cause

Apple restore images can leave a seven-sector gap between the recovery partition and lastUsableLBA. The previous equality guard treated that valid layout as unsupported, but the caller still installed the enlarged file and cleared resizePending. That left users with a larger host file, an unchanged GPT, and no UI path to retry.

Reported in https://github.com/insidegui/VirtualBuddy/discussions/742.

## Validation

- git diff --check upstream/main...HEAD
- Unaligned UInt64 GPT decoding compatibility check
- Full VirtualWormhole XCTest attempted with Xcode 27; currently blocked before test execution by the existing upstream compile error in VirtualCore/Source/Definitions/PreviewSupport.swift:14

## Deliberately excluded

The APFS resizeContainer shrink and grow nudge is not automated here pending reproduction inside the guest, where space claiming is delegated.