### PR TITLE
Fix Linux catalog missing mandatory legacyGuestAppVersions key

### DIFF
--- a/data/linux_v2.json
+++ b/data/linux_v2.json
@@ -182,6 +182,8 @@
       "name" : "Kali"
     }
   ],
+    "legacyGuestAppVersions": [
+    ],
   "minAppVersion" : "2.0.0",
   "requirementSets" : [
     {


### PR DESCRIPTION
Fixes blank Linux page when choosing Linux as guest OS.