### PR TITLE
Fix configuration sheet performance issue

### DIFF
--- a/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
+++ b/VirtualCore/Source/Models/Configuration/ConfigurationModels.swift
@@ -462,6 +462,20 @@ public struct VBMacProvisioningConfiguration: Hashable, Codable, Sendable {
         self.username = username
         self._password = password
     }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(enablesRemoteLogin)
+        hasher.combine(logsInAutomatically)
+        hasher.combine(fullName)
+        hasher.combine(username)
+    }
+
+    public static func ==(lhs: VBMacProvisioningConfiguration, rhs: VBMacProvisioningConfiguration) -> Bool {
+        lhs.enablesRemoteLogin == rhs.enablesRemoteLogin
+        && lhs.logsInAutomatically == rhs.logsInAutomatically
+        && lhs.fullName == rhs.fullName
+        && lhs.username == rhs.username
+    }
 }
 
 public extension VBMacProvisioningConfiguration {

--- a/VirtualCore/Source/Utilities/KeychainReference.swift
+++ b/VirtualCore/Source/Utilities/KeychainReference.swift
@@ -3,7 +3,7 @@ import OSLog
 
 /// A type that can be stored in an encodable parent that wants one of its properties to reference a Keychain item.
 @propertyWrapper
-public struct KeychainReference: Codable, Hashable, Sendable {
+public struct KeychainReference: Codable, Sendable {
     private let logger = Logger(subsystem: "codes.rambo.VirtualCore", category: String(describing: KeychainReference.self))
 
     public var wrappedValue: String {
@@ -110,16 +110,5 @@ public struct KeychainReference: Codable, Hashable, Sendable {
         let string = encodableString()
 
         try container.encode(string)
-    }
-
-    // MARK: - Hashable
-
-    public func hash(into hasher: inout Hasher) {
-        let value = read() ?? ""
-        hasher.combine(value)
-    }
-
-    public static func ==(lhs: Self, rhs: Self) -> Bool {
-        lhs.read() == rhs.read()
     }
 }

--- a/VirtualUI/Source/VM Configuration/VMConfigurationView.swift
+++ b/VirtualUI/Source/VM Configuration/VMConfigurationView.swift
@@ -124,44 +124,47 @@ struct VMConfigurationView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            if showTemplatePicker {
-                templatePicker
+            Group {
+                if showTemplatePicker {
+                    templatePicker
+                }
+    
+                if showBootDiskSection {
+                    bootDisk
+                }
+    
+                general
+    
+                if showProvisioningSection {
+                    provisioning
+                }
+    
+                storage
+
+                usbDevices
+
+                display
+
+                if showPointingDeviceSection {
+                    pointingDevice
+                }
+
+                if showKeyboardDeviceSection {
+                    keyboardDevice
+                }
+
+                network
+
+                sound
+
+                if showGuestAppSection {
+                    guestApp
+                }
+
+                sharing
             }
-
-            if showBootDiskSection {
-                bootDisk
-            }
-
-            general
-
-            if showProvisioningSection {
-                provisioning
-            }
-
-            storage
-
-            usbDevices
-
-            display
-
-            if showPointingDeviceSection {
-                pointingDevice
-            }
-
-            if showKeyboardDeviceSection {
-                keyboardDevice
-            }
-
-            network
-
-            sound
-
-            if showGuestAppSection {
-                guestApp
-            }
-
-            sharing
-                .frame(minWidth: 0, idealWidth: VMConfigurationSheet.minWidth)
+            /// This is required so that contents that have long text content won't cause the width to expand automatically.
+            .frame(minWidth: 0, idealWidth: VMConfigurationSheet.minWidth)
         }
         .font(.system(size: 12))
         .environment(\.configurationGuestType, viewModel.config.systemType)


### PR DESCRIPTION
Provisioning configuration was reading from the Keychain to implement Hashable conformance, which was not needed and was causing a severe hang in macOS 27 when opening the configuration sheet.

Also fixes a sizing bug that caused the sheet to be much wider than needed.