### PR TITLE
Fix boot deep link not working when VM window already open

### DIFF
--- a/VirtualBuddy/Automation/DeepLinkHandler.swift
+++ b/VirtualBuddy/Automation/DeepLinkHandler.swift
@@ -6,6 +6,11 @@ import DeepLinkSecurity
 
 typealias WindowUpdatingClosure = (_ perform: () -> Void) -> Void
 
+extension Notification.Name {
+    /// Notification sent from ``DeepLinkHandler`` when it wants the SwiftUI app to open the library window.
+    static let openVirtualBuddyLibraryWindow = Notification.Name("codes.rambo.VirtualBuddy.OpenLibraryWindow")
+}
+
 final class DeepLinkHandler {
 
     private let settingsContainer: VBSettingsContainer
@@ -102,6 +107,8 @@ final class DeepLinkHandler {
         func run(_ action: DeepLinkAction) async {
             do {
                 switch action {
+                case .library:
+                    NotificationCenter.default.post(name: .openVirtualBuddyLibraryWindow, object: action)
                 case .open(let params):
                     try openVM(named: params.name, options: nil)
                 case .boot(let params):

--- a/VirtualBuddy/Automation/VirtualBuddyDeepLinks.swift
+++ b/VirtualBuddy/Automation/VirtualBuddyDeepLinks.swift
@@ -18,6 +18,7 @@ struct StopVMParameters: Codable {
 }
 
 enum DeepLinkAction  {
+    case library
     case open(OpenVMParameters)
     case boot(BootVMParameters)
     case stop(StopVMParameters)
@@ -33,6 +34,8 @@ extension DeepLinkAction {
         }
 
         switch host {
+        case "library":
+            self = .library
         case "open":
             let params = try Self.decodeParameters(OpenVMParameters.self, from: components)
             self = .open(params)

--- a/VirtualBuddy/Bootstrap/VirtualBuddyApp.swift
+++ b/VirtualBuddy/Bootstrap/VirtualBuddyApp.swift
@@ -43,6 +43,9 @@ struct VirtualBuddyApp: App {
                 }
                 .environment(\.openVirtualBuddySettings, appDelegate.openSettingsAction)
                 .background { TransparentWindowTitleBarView() }
+                .onReceive(NotificationCenter.default.publisher(for: .openVirtualBuddyLibraryWindow)) { _ in
+                    openLibraryWindow()
+                }
         }
         .windowToolbarStyle(.unified)
         .commands {
@@ -73,12 +76,16 @@ struct VirtualBuddyApp: App {
 
             CommandGroup(after: .windowArrangement) {
                 Button("Library") {
-                    openWindow(id: .vb_libraryWindowID)
+                    openLibraryWindow()
                 }
                 .keyboardShortcut(KeyEquivalent("0"), modifiers: .command)
             }
         }
         .handlesExternalEvents(matching: ["*"])
+    }
+
+    private func openLibraryWindow() {
+        openWindow(id: .vb_libraryWindowID)
     }
 }
 

--- a/VirtualUI/Source/Session/VirtualMachineSessionView.swift
+++ b/VirtualUI/Source/Session/VirtualMachineSessionView.swift
@@ -68,7 +68,7 @@ public struct VirtualMachineSessionView: View {
         .onReceive(ui.makeWindowKey) {
             window?.makeKeyAndOrderFront(nil)
         }
-        .task {
+        .task(id: controller.options.autoBoot) {
             if controller.options.autoBoot {
                 Task { try? await controller.start() }
             }


### PR DESCRIPTION
- Fixes issue described here: https://github.com/insidegui/VirtualBuddy/discussions/755
- Also fixes `virtualbuddy://library` deep link not reopening the library window after it's closed