### PR TITLE
Write catalog JSON with a trailing newline

### DIFF
--- a/VirtualCore/Source/VirtualCatalog/SoftwareCatalog.swift
+++ b/VirtualCore/Source/VirtualCatalog/SoftwareCatalog.swift
@@ -280,7 +280,11 @@ public extension SoftwareCatalog {
     }
 
     func write(to url: URL) throws {
-        try Self.encoder.encode(self).write(to: url)
+        var data = try Self.encoder.encode(self)
+        if data.last != 0x0A {
+            data.append(0x0A)
+        }
+        try data.write(to: url)
     }
 }
 


### PR DESCRIPTION
`JSONEncoder` output ends at the closing brace, so vctool was stripping the trailing newline from the catalogs under `data/`. The writer now appends one unless it's already there.